### PR TITLE
feat: azurem bump to 3.39.x (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## v0.2.0 (January 13, 2023)
+## v0.2.0 (March 7, 2023)
 
-* Azure Provider upgrade from 2.x to 3.x
+* Mininum Azure Provider upgrade from 2.x to 3.x (3.46.x)
 * refactor resources for 3.x provider: azurerm_public_ip, azurerm_lb_probe, and cc_lb_rule
-* Fix for Azure Load Balancer frontend_ip creation in Regions that do not support availability zones
+* Fix for Azure Load Balancer frontend_ip creation in Regions that do not support availability zones. If a single zone is specified to variable "zones" and variable "zones_enabled" is true then the frontend_ip will be created in that single zone. If more than one zone is specified, we will default to all 3 zones (zone-redundant) to follow Azure Network API
+* Fix for NSG data source read dependency when resource orginally created (byo_nsg = false) forcing recreate on subsequent terraform applies
 
 ## v0.1.1 (December 16, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.2.0 (January 13, 2023)
+
+* Azure Provider upgrade from 2.x to 3.x
+* refactor resources for 3.x provider: azurerm_public_ip, azurerm_lb_probe, and cc_lb_rule
+* Fix for Azure Load Balancer frontend_ip creation in Regions that do not support availability zones
+
 ## v0.1.1 (December 16, 2022)
 
 * comprehensive README

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use this repository to create the deployment resources required to deploy and op
 
 Our Deployment scripts are leveraging Terraform v1.1.9 which includes full binary and provider support for macOS M1 chips, but any Terraform version 0.13.7 should be generally supported.
 
-- provider registry.terraform.io/hashicorp/azurerm v2.99.x
+- provider registry.terraform.io/hashicorp/azurerm v3.46.x
 - provider registry.terraform.io/hashicorp/random v3.3.x
 - provider registry.terraform.io/hashicorp/local v2.2.x
 - provider registry.terraform.io/hashicorp/null v3.1.x

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -40,7 +40,7 @@ From base directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -40,7 +40,7 @@ From base directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -41,7 +41,7 @@ From base_1cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -41,7 +41,7 @@ From base_1cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_1cc/versions.tf
+++ b/examples/base_1cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc/versions.tf
+++ b/examples/base_1cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_lb/README.md
+++ b/examples/base_cc_lb/README.md
@@ -42,7 +42,7 @@ From base_cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_cc_lb/README.md
+++ b/examples/base_cc_lb/README.md
@@ -42,7 +42,7 @@ From base_cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_cc_lb/main.tf
+++ b/examples/base_cc_lb/main.tf
@@ -203,6 +203,8 @@ module "cc_lb" {
   subnet_id         = module.network.cc_subnet_ids[0]
   http_probe_port   = var.http_probe_port
   load_distribution = var.load_distribution
+  zones_enabled     = var.zones_enabled
+  zones             = var.zones
 }
 
 

--- a/examples/base_cc_lb/versions.tf
+++ b/examples/base_cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_lb/versions.tf
+++ b/examples/base_cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_lb/README.md
+++ b/examples/cc_lb/README.md
@@ -45,7 +45,7 @@ From cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/cc_lb/README.md
+++ b/examples/cc_lb/README.md
@@ -45,7 +45,7 @@ From cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/cc_lb/main.tf
+++ b/examples/cc_lb/main.tf
@@ -185,6 +185,8 @@ module "cc_lb" {
   subnet_id         = module.network.cc_subnet_ids[0]
   http_probe_port   = var.http_probe_port
   load_distribution = var.load_distribution
+  zones_enabled     = var.zones_enabled
+  zones             = var.zones
 }
 
 

--- a/examples/cc_lb/versions.tf
+++ b/examples/cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_lb/versions.tf
+++ b/examples/cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/terraform-zscc-bastion-azure/README.md
+++ b/modules/terraform-zscc-bastion-azure/README.md
@@ -8,13 +8,13 @@ This module creates all Azure VM, NSG, and Public IP resources needed to deploy 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.46.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-bastion-azure/README.md
+++ b/modules/terraform-zscc-bastion-azure/README.md
@@ -8,13 +8,13 @@ This module creates all Azure VM, NSG, and Public IP resources needed to deploy 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.99.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-bastion-azure/versions.tf
+++ b/modules/terraform-zscc-bastion-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-bastion-azure/versions.tf
+++ b/modules/terraform-zscc-bastion-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-ccvm-azure/README.md
+++ b/modules/terraform-zscc-ccvm-azure/README.md
@@ -21,7 +21,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -29,7 +29,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.46.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 
 ## Modules

--- a/modules/terraform-zscc-ccvm-azure/README.md
+++ b/modules/terraform-zscc-ccvm-azure/README.md
@@ -21,7 +21,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -29,7 +29,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.99.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 
 ## Modules

--- a/modules/terraform-zscc-ccvm-azure/versions.tf
+++ b/modules/terraform-zscc-ccvm-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-ccvm-azure/versions.tf
+++ b/modules/terraform-zscc-ccvm-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-identity-azure/README.md
+++ b/modules/terraform-zscc-identity-azure/README.md
@@ -8,13 +8,13 @@ This module takes name and resource group inputs of an existing User Managed Ide
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.99.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-identity-azure/README.md
+++ b/modules/terraform-zscc-identity-azure/README.md
@@ -8,13 +8,13 @@ This module takes name and resource group inputs of an existing User Managed Ide
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.46.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-identity-azure/versions.tf
+++ b/modules/terraform-zscc-identity-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-identity-azure/versions.tf
+++ b/modules/terraform-zscc-identity-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-lb-azure/README.md
+++ b/modules/terraform-zscc-lb-azure/README.md
@@ -8,13 +8,13 @@ This module creates a Standard Load Balancer, backend addres pool, LB rules, and
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.99.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
 
 ## Modules
 
@@ -41,6 +41,8 @@ No modules.
 | <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Main Resource Group Name | `string` | n/a | yes |
 | <a name="input_resource_tag"></a> [resource\_tag](#input\_resource\_tag) | A tag to associate to all the lb module resources | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID for LB Frontend IP placement | `string` | n/a | yes |
+| <a name="input_zones"></a> [zones](#input\_zones) | Specify which availability zone(s) to deploy VM resources in if zones\_enabled variable is set to true | `list(string)` | <pre>[<br>  "1"<br>]</pre> | no |
+| <a name="input_zones_enabled"></a> [zones\_enabled](#input\_zones\_enabled) | Determine whether to provision Cloud Connector VMs explicitly in defined zones (if supported by the Azure region provided in the location variable). If left false, Azure will automatically choose a zone and module will create an availability set resource instead for VM fault tolerance | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/terraform-zscc-lb-azure/README.md
+++ b/modules/terraform-zscc-lb-azure/README.md
@@ -8,13 +8,13 @@ This module creates a Standard Load Balancer, backend addres pool, LB rules, and
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.46.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-lb-azure/main.tf
+++ b/modules/terraform-zscc-lb-azure/main.tf
@@ -25,8 +25,8 @@ resource "azurerm_lb" "cc_lb" {
   frontend_ip_configuration {
     name                          = "${var.name_prefix}-cc-lb-ip-${var.resource_tag}"
     subnet_id                     = var.subnet_id
-    private_ip_address_allocation = "Dynamic"
-    zones                         = local.zones_supported ? var.zones : null
+    private_ip_address_allocation = "dynamic"
+    zones                         = local.zones_supported ? local.frontend_zone_specific : null
   }
 }
 

--- a/modules/terraform-zscc-lb-azure/main.tf
+++ b/modules/terraform-zscc-lb-azure/main.tf
@@ -26,6 +26,7 @@ resource "azurerm_lb" "cc_lb" {
     name                          = "${var.name_prefix}-cc-lb-ip-${var.resource_tag}"
     subnet_id                     = var.subnet_id
     private_ip_address_allocation = "Dynamic"
+    zones                         = local.zones_supported ? var.zones : null
   }
 }
 
@@ -43,12 +44,11 @@ resource "azurerm_lb_backend_address_pool" "cc_lb_backend_pool" {
 # Define load balancer health probe parameters
 ################################################################################
 resource "azurerm_lb_probe" "cc_lb_probe" {
-  name                = "${var.name_prefix}-cc-lb-probe-${var.resource_tag}"
-  resource_group_name = var.resource_group
-  loadbalancer_id     = azurerm_lb.cc_lb.id
-  protocol            = "Http"
-  port                = var.http_probe_port
-  request_path        = "/?cchealth"
+  name            = "${var.name_prefix}-cc-lb-probe-${var.resource_tag}"
+  loadbalancer_id = azurerm_lb.cc_lb.id
+  protocol        = "Http"
+  port            = var.http_probe_port
+  request_path    = "/?cchealth"
 }
 
 
@@ -57,7 +57,6 @@ resource "azurerm_lb_probe" "cc_lb_probe" {
 ################################################################################
 resource "azurerm_lb_rule" "cc_lb_rule" {
   name                           = "${var.name_prefix}-cc-lb-rule-${var.resource_tag}"
-  resource_group_name            = var.resource_group
   loadbalancer_id                = azurerm_lb.cc_lb.id
   protocol                       = "All"
   frontend_port                  = 0

--- a/modules/terraform-zscc-lb-azure/variables.tf
+++ b/modules/terraform-zscc-lb-azure/variables.tf
@@ -57,3 +57,29 @@ variable "load_distribution" {
     error_message = "Input load_distribution must be set to either SourceIP, SourceIPProtocol, or Default."
   }
 }
+
+# Validation to determine if Azure Region selected supports availabilty zones if desired
+locals {
+  az_supported_regions = ["australiaeast", "Australia East", "brazilsouth", "Brazil South", "canadacentral", "Canada Central", "centralindia", "Central India", "centralus", "Central US", "eastasia", "East Asia", "eastus", "East US", "francecentral", "France Central", "germanywestcentral", "Germany West Central", "japaneast", "Japan East", "koreacentral", "Korea Central", "northeurope", "North Europe", "norwayeast", "Norway East", "southafricanorth", "South Africa North", "southcentralus", "South Central US", "southeastasia", "Southeast Asia", "swedencentral", "Sweden Central", "uksouth", "UK South", "westeurope", "West Europe", "westus2", "West US 2", "westus3", "West US 3"]
+  zones_supported = (
+    contains(local.az_supported_regions, var.location) && var.zones_enabled == true
+  )
+}
+
+variable "zones_enabled" {
+  type        = bool
+  description = "Determine whether to provision Cloud Connector VMs explicitly in defined zones (if supported by the Azure region provided in the location variable). If left false, Azure will automatically choose a zone and module will create an availability set resource instead for VM fault tolerance"
+  default     = false
+}
+
+variable "zones" {
+  type        = list(string)
+  description = "Specify which availability zone(s) to deploy VM resources in if zones_enabled variable is set to true"
+  default     = ["1"]
+  validation {
+    condition = (
+      !contains([for zones in var.zones : contains(["1", "2", "3"], zones)], false)
+    )
+    error_message = "Input zones variable must be a number 1-3."
+  }
+}

--- a/modules/terraform-zscc-lb-azure/variables.tf
+++ b/modules/terraform-zscc-lb-azure/variables.tf
@@ -64,6 +64,7 @@ locals {
   zones_supported = (
     contains(local.az_supported_regions, var.location) && var.zones_enabled == true
   )
+  frontend_zone_specific = length(var.zones) == 1 ? var.zones : ["1", "2", "3"] ##If user specifies a single zone number for a zones supported region set just that zone. Otherwise, set all 3 zones (zone-redundant)
 }
 
 variable "zones_enabled" {

--- a/modules/terraform-zscc-lb-azure/versions.tf
+++ b/modules/terraform-zscc-lb-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-lb-azure/versions.tf
+++ b/modules/terraform-zscc-lb-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-network-azure/README.md
+++ b/modules/terraform-zscc-network-azure/README.md
@@ -8,13 +8,13 @@ This module has multi-purpose use and is leveraged by all other Zscaler Cloud Co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.46.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-network-azure/README.md
+++ b/modules/terraform-zscc-network-azure/README.md
@@ -8,13 +8,13 @@ This module has multi-purpose use and is leveraged by all other Zscaler Cloud Co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.99.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-network-azure/main.tf
+++ b/modules/terraform-zscc-network-azure/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_public_ip" "pip" {
   allocation_method       = "Static"
   sku                     = "Standard"
   idle_timeout_in_minutes = 30
-  availability_zone       = local.zones_supported ? element(var.zones, count.index) : local.pip_zones
+  zones                   = local.zones_supported ? [element(var.zones, count.index)] : null
 
   tags = var.global_tags
 

--- a/modules/terraform-zscc-network-azure/variables.tf
+++ b/modules/terraform-zscc-network-azure/variables.tf
@@ -51,7 +51,6 @@ locals {
   zones_supported = (
     contains(local.az_supported_regions, var.location) && var.zones_enabled == true
   )
-  pip_zones = contains(local.az_supported_regions, var.location) ? "Zone-Redundant" : "No-Zone"
 }
 
 variable "zones_enabled" {

--- a/modules/terraform-zscc-network-azure/versions.tf
+++ b/modules/terraform-zscc-network-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
     local = {
       source = "hashicorp/local"

--- a/modules/terraform-zscc-network-azure/versions.tf
+++ b/modules/terraform-zscc-network-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
     local = {
       source = "hashicorp/local"

--- a/modules/terraform-zscc-nsg-azure/README.md
+++ b/modules/terraform-zscc-nsg-azure/README.md
@@ -8,13 +8,13 @@ This module can be used to create default Management and Service interface NSG r
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.99.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-nsg-azure/README.md
+++ b/modules/terraform-zscc-nsg-azure/README.md
@@ -8,13 +8,13 @@ This module can be used to create default Management and Service interface NSG r
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.46.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-nsg-azure/main.tf
+++ b/modules/terraform-zscc-nsg-azure/main.tf
@@ -48,8 +48,8 @@ resource "azurerm_network_security_group" "cc_mgmt_nsg" {
 
 # Or use existing Mgmt NSG
 data "azurerm_network_security_group" "mgt_nsg_selected" {
-  count               = var.byo_nsg == false ? length(azurerm_network_security_group.cc_mgmt_nsg[*].id) : length(var.byo_mgmt_nsg_names)
-  name                = var.byo_nsg == false ? "${var.name_prefix}-cc-mgmt-nsg-${count.index + 1}-${var.resource_tag}" : element(var.byo_mgmt_nsg_names, count.index)
+  count               = var.byo_nsg ? length(var.byo_mgmt_nsg_names) : 0
+  name                = var.byo_nsg ? element(var.byo_mgmt_nsg_names, count.index) : 0
   resource_group_name = var.resource_group
 }
 
@@ -92,7 +92,7 @@ resource "azurerm_network_security_group" "cc_service_nsg" {
 
 # Or use existing Service NSG
 data "azurerm_network_security_group" "service_nsg_selected" {
-  count               = var.byo_nsg == false ? length(azurerm_network_security_group.cc_service_nsg[*].id) : length(var.byo_service_nsg_names)
-  name                = var.byo_nsg == false ? "${var.name_prefix}-cc-service-nsg-${count.index + 1}-${var.resource_tag}" : element(var.byo_service_nsg_names, count.index)
+  count               = var.byo_nsg ? length(var.byo_service_nsg_names) : 0
+  name                = var.byo_nsg ? element(var.byo_service_nsg_names, count.index) : 0
   resource_group_name = var.resource_group
 }

--- a/modules/terraform-zscc-nsg-azure/outputs.tf
+++ b/modules/terraform-zscc-nsg-azure/outputs.tf
@@ -1,9 +1,9 @@
 output "mgmt_nsg_id" {
   description = "Management Network Security Group ID"
-  value       = data.azurerm_network_security_group.mgt_nsg_selected[*].id
+  value       = var.byo_nsg ? data.azurerm_network_security_group.mgt_nsg_selected[*].id : azurerm_network_security_group.cc_mgmt_nsg[*].id
 }
 
 output "service_nsg_id" {
   description = "Service Network Security Group ID"
-  value       = data.azurerm_network_security_group.service_nsg_selected[*].id
+  value       = var.byo_nsg ? data.azurerm_network_security_group.service_nsg_selected[*].id : azurerm_network_security_group.cc_service_nsg[*].id
 }

--- a/modules/terraform-zscc-nsg-azure/versions.tf
+++ b/modules/terraform-zscc-nsg-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-nsg-azure/versions.tf
+++ b/modules/terraform-zscc-nsg-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-workload-azure/README.md
+++ b/modules/terraform-zscc-workload-azure/README.md
@@ -8,13 +8,13 @@ This module creates all Azure VM and NSG resources needed to deploy test workloa
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.46.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.46.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-workload-azure/README.md
+++ b/modules/terraform-zscc-workload-azure/README.md
@@ -8,13 +8,13 @@ This module creates all Azure VM and NSG resources needed to deploy test workloa
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.99.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.99.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.39.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-workload-azure/versions.tf
+++ b/modules/terraform-zscc-workload-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.39.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-workload-azure/versions.tf
+++ b/modules/terraform-zscc-workload-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.0"
+      version = "~> 3.46.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"


### PR DESCRIPTION
* refactor resources for 3.x provider: azurerm_public_ip, azurerm_lb_probe, and cc_lb_rule
* Fix for Azure Load Balancer frontend_ip creation in Regions that do not support availability zones