### PR TITLE
fix: brownfield cc_lb defaults for non-zpa private dns deployments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 /.github/ @dshailen
 /.github/ @smone77
 /.github/ @vkrishnamurthy-zscaler
+/.github/ @nmizhquirizs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.1 (October 23, 2023)
+
+BUG FIXES:
+* fix: brownfield cc_lb defaults for non-zpa private dns deployments
+
 ## v0.3.0 (September 30, 2023)
 
 FEATURES:

--- a/examples/cc_lb/README.md
+++ b/examples/cc_lb/README.md
@@ -117,7 +117,7 @@ From cc_lb directory execute:
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
-| <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector | `map(any)` | n/a | yes |
+| <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector | `map(any)` | `{}` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `false` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Customer defined environment tag. ie: Dev, QA, Prod, etc. | `string` | `"Development"` | no |
@@ -138,7 +138,7 @@ From cc_lb directory execute:
 | <a name="input_tls_key_algorithm"></a> [tls\_key\_algorithm](#input\_tls\_key\_algorithm) | algorithm for tls\_private\_key resource | `string` | `"RSA"` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | Specify which availability zone(s) to deploy VM resources in if zones\_enabled variable is set to true | `list(string)` | <pre>[<br>  "1"<br>]</pre> | no |
 | <a name="input_zones_enabled"></a> [zones\_enabled](#input\_zones\_enabled) | Determine whether to provision Cloud Connector VMs explicitly in defined zones (if supported by the Azure region provided in the location variable). If left false, Azure will automatically choose a zone and module will create an availability set resource instead for VM fault tolerance | `bool` | `false` | no |
-| <a name="input_zpa_enabled"></a> [zpa\_enabled](#input\_zpa\_enabled) | Configure Azure Private DNS Outbound subnet, Resolvers, Rulesets/Rules, and Outbound Endpoint ZPA DNS redirection | `bool` | `true` | no |
+| <a name="input_zpa_enabled"></a> [zpa\_enabled](#input\_zpa\_enabled) | Configure Azure Private DNS Outbound subnet, Resolvers, Rulesets/Rules, and Outbound Endpoint ZPA DNS redirection | `bool` | `false` | no |
 
 ## Outputs
 

--- a/examples/cc_lb/outputs.tf
+++ b/examples/cc_lb/outputs.tf
@@ -32,13 +32,13 @@ All NAT GW IPs:
 ${join("\n", module.network.public_ip_address)}
 
 Private DNS Resolver:
-${try(module.private_dns.private_dns_resolver_name, "")}
+${try(module.private_dns.private_dns_resolver_name, "N/A")}
 
 Private DNS Forwarding Ruleset:
-${try(module.private_dns.private_dns_forwarding_ruleset_name, "")}
+${try(module.private_dns.private_dns_forwarding_ruleset_name, "N/A")}
 
 Private DNS Outbound Endpoint:
-${try(module.private_dns.private_dns_outbound_endpoint_name, "")}
+${try(module.private_dns.private_dns_outbound_endpoint_name, "N/A")}
 
 TB
 }

--- a/examples/cc_lb/terraform.tfvars
+++ b/examples/cc_lb/terraform.tfvars
@@ -288,7 +288,12 @@
 #####################################################################################################################
 ##### ZPA/Azure Private DNS specific variables #####
 #####################################################################################################################
-## 39. Provide the domain names you want Azure Private DNS to redirect to Cloud Connector for ZPA interception. 
+## 39. By default, the terraform-zscc-private-dns-azure (Azure Private DNS for ZPA) module and dependences are not 
+##     configured. Uncomment and set to true to enable this module resources creation.
+
+#zpa_enabled                            = true
+
+## 40. Provide the domain names you want Azure Private DNS to redirect to Cloud Connector for ZPA interception. 
 ##     Only applicable for base + zpa or zpa_enabled = true deployment types where Outbound DNS subnets, Resolver Ruleset/Rules, 
 ##     and Outbound Endpoints are being created. Two example domains are populated to show the mapping structure and syntax.
 ##     Azure does require a trailing dot "." on all domain entries. ZPA Module will read through each to create a resolver rule per 
@@ -299,7 +304,7 @@
 #  appseg2 = "app2.com."
 #}
 
-## 40. Azure Private DNS queries will be conditionally forwarded to these target IP addresses. Default are a pair of Zscaler Global VIP addresses.
+## 41. Azure Private DNS queries will be conditionally forwarded to these target IP addresses. Default are a pair of Zscaler Global VIP addresses.
 ##     The required expectation is that the target should follow VNet/subnet routing towards the configured Cloud Connector Load Balancer VIP for 
 ##     ZPA DNS interception
 

--- a/examples/cc_lb/variables.tf
+++ b/examples/cc_lb/variables.tf
@@ -252,12 +252,13 @@ variable "encryption_at_host_enabled" {
 variable "zpa_enabled" {
   type        = bool
   description = "Configure Azure Private DNS Outbound subnet, Resolvers, Rulesets/Rules, and Outbound Endpoint ZPA DNS redirection"
-  default     = true
+  default     = false
 }
 
 variable "domain_names" {
   type        = map(any)
   description = "Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector"
+  default     = {}
 }
 
 variable "target_address" {


### PR DESCRIPTION
this is just tweaking some defaults to not inadvertently prompt users for modules when not used