### PR TITLE
feat: removing the assignment of Storage Blob Data Reader to the managed identity in terraform

### DIFF
--- a/modules/terraform-zscc-function-app-azure/main.tf
+++ b/modules/terraform-zscc-function-app-azure/main.tf
@@ -43,14 +43,6 @@ resource "azurerm_storage_blob" "cc_function_storage_blob" {
   content_md5            = filemd5("${path.module}/zscaler_cc_function_app.zip")
 }
 
-# Restrict storage account blob access to only CC/Function App Managed Identity
-resource "azurerm_role_assignment" "cc_function_role_assignment_storage" {
-  count                = var.upload_function_app_zip ? 1 : 0
-  scope                = local.storage_account_id
-  role_definition_name = "Storage Blob Data Reader"
-  principal_id         = var.managed_identity_principal_id
-}
-
 # Create App Service Plan
 resource "azurerm_service_plan" "vmss_orchestration_app_service_plan" {
   name                = "${var.name_prefix}-ccvmss-${var.resource_tag}-app-service-plan"


### PR DESCRIPTION
Similar to other permission management, this will become a prerequisite for customers to add to their managed identities before deploying the terraform. The removal of this avoids customers needing to have elevated permissions granted to them to deploy this solution.

