### PR TITLE
azurerm provider bump to 3.116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.6.1 (October 5, 2024)
+
+BUG FIXES:
+* AzureRM Provider version bump to 3.116.x default to address provider: skip registration for resource providers that are unavailable
+* refactor: update Azure deprecated arguments:
+    - azurerm_network_interface: enable_ip_forwarding change to ip_forwarding_enabled and enable_accelerated_networking to accelerated_networking_enabled
+    - azurerm_route_table: disable_bgp_route_propagation (default true) change to bgp_route_propagation_enabled (default false)
+
+ENHANCEMENTS:
+* zsec support server lookup resiliency impreovements
+
 ## v0.6.0 (September 5, 2024)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ BUG FIXES:
     - azurerm_route_table: disable_bgp_route_propagation (default true) change to bgp_route_propagation_enabled (default false)
 
 ENHANCEMENTS:
-* zsec support server lookup resiliency impreovements
+* zsec support server lookup resiliency improvements
 
 ## v0.6.0 (September 5, 2024)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use this repository to create the deployment resources required to deploy and op
 
 Our Deployment scripts are leveraging Terraform v1.1.9 which includes full binary and provider support for macOS M1 chips, but any Terraform version 0.13.7 should be generally supported.
 
-- provider registry.terraform.io/hashicorp/azurerm v3.74.x (minimum 3.46.x)
+- provider registry.terraform.io/hashicorp/azurerm v3.116.x (minimum 3.46.x)
 - provider registry.terraform.io/hashicorp/random v3.3.x
 - provider registry.terraform.io/hashicorp/local v2.2.x
 - provider registry.terraform.io/hashicorp/null v3.1.x

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -40,7 +40,7 @@ From base directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -41,7 +41,7 @@ From base_1cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_1cc/versions.tf
+++ b/examples/base_1cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc_zpa/README.md
+++ b/examples/base_1cc_zpa/README.md
@@ -41,7 +41,7 @@ From base_1cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -51,7 +51,7 @@ From base_1cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base_1cc_zpa/versions.tf
+++ b/examples/base_1cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_lb/README.md
+++ b/examples/base_cc_lb/README.md
@@ -42,7 +42,7 @@ From base_cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_cc_lb/versions.tf
+++ b/examples/base_cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_lb_zpa/README.md
+++ b/examples/base_cc_lb_zpa/README.md
@@ -42,7 +42,7 @@ From base_cc_lb_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -52,7 +52,7 @@ From base_cc_lb_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base_cc_lb_zpa/versions.tf
+++ b/examples/base_cc_lb_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_vmss/README.md
+++ b/examples/base_cc_vmss/README.md
@@ -222,7 +222,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_cc_vmss/versions.tf
+++ b/examples/base_cc_vmss/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_vmss_zpa/README.md
+++ b/examples/base_cc_vmss_zpa/README.md
@@ -209,7 +209,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -219,7 +219,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base_cc_vmss_zpa/versions.tf
+++ b/examples/base_cc_vmss_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_lb/README.md
+++ b/examples/cc_lb/README.md
@@ -45,7 +45,7 @@ From cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/cc_lb/versions.tf
+++ b/examples/cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_vmss/README.md
+++ b/examples/cc_vmss/README.md
@@ -211,7 +211,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/cc_vmss/versions.tf
+++ b/examples/cc_vmss/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/zsec
+++ b/examples/zsec
@@ -28,8 +28,7 @@ else
     esac
 fi
 
-
-if [[ "$oper" == "up" ]]; then
+if [[ "$oper" == "up" && ! -e ./.zsecrc ]]; then
     PS3="${CYAN}Select your Zscaler Cloud: ${RESET}"
     zs_clouds=("zscloud.net" "zscaler.net" "zscalertwo.net" "zscalerthree.net" "zscalerten.net" "zscalerbeta.net" "other")
     select zscaler_cloud in "${zs_clouds[@]}"
@@ -94,144 +93,153 @@ if [[ "$oper" == "up" ]]; then
                 done
                 break
                 ;;
-                *) 
-                    echo "${RED}Invalid response. Please enter a number selection${RESET}"
-            esac
-        done
-
-    PS3="${CYAN}Select desired deployment: ${RESET}"
-    deployments=("greenfield - Recommended for isolated test/POV deployments. Creates new network infrastructure, test workloads, and a public jump host" "brownfield - Recommended for prod deployments. Bring-your-own existing network infrastructure customizations + no workload/bastion creation")
-    select deployment in "${deployments[@]}"
-    do
-        case $REPLY in
-            1)
-                echo "${GREEN}Greenfield deployment selected...${RESET}"
-                echo "${YELLOW}**Caution** These deployments include test workloads and publicly accessible jump hosts and are intended primarily for lab/test environments${RESET}"
-                echo ""
-                deployment=greenfield
-            break
-            ;;
-            2)
-                echo "${GREEN}Brownfield deployment selected...${RESET}"
-                deployment=brownfield
-            break
-            ;;
             *) 
                 echo "${RED}Invalid response. Please enter a number selection${RESET}"
         esac
     done
-    
-    if [[ "$zscaler_cloud" == "zscalerten.net" ]]; then
-        echo "${YELLOW}Zscalerten does not currently support Auto Scaling VMSS. Proceeding with standard deployment options...${RESET}"
-        if [[ "$deployment" == "greenfield" ]]; then 
-            vmss_enabled=false
-        elif [[ "$deployment" == "brownfield" ]]; then
-            echo "${GREEN}Proceeding with brownfield manual scaling with load balancer configuration...${RESET}"
-            vmss_enabled=false
-            #implicitly set dtype as cc_lb for brownfield + no vmss
-            dtype=cc_lb
-        fi
-    else
-        while true; do
-            read -r -p "${CYAN}Deploy Cloud Connectors in Auto Scaling VMSS? [yes/no]: ${RESET}" response
-            case $response in 
-            yes|y )
-                if [[ "$deployment" == "greenfield" ]]; then 
-                    echo "${GREEN}Proceeding with greenfield Virtual Machine Scale Sets configuration...${RESET}"
-                    vmss_enabled=true
-                elif [[ "$deployment" == "brownfield" ]]; then
-                    echo "${GREEN}Proceeding with brownfield Virtual Machine Scale Sets configuration...${RESET}"
-                    vmss_enabled=true
-                    #implicitly set dtype as cc_vmss for brownfield + vmss
-                    dtype=cc_vmss
-                fi
-            break
-            ;;
-            no|n )
-                if [[ "$deployment" == "greenfield" ]]; then 
-                    echo "${GREEN}Proceeding with greenfield manual scaling configuration...${RESET}"
-                    vmss_enabled=false
-                elif [[ "$deployment" == "brownfield" ]]; then
-                    echo "${GREEN}Proceeding with brownfield manual scaling with load balancer configuration...${RESET}"
-                    vmss_enabled=false
-                    #implicitly set dtype as cc_lb for brownfield + no vmss
-                    dtype=cc_lb
-                fi
-            break
-            ;;
-                * ) echo "${RED}Invalid response. Please enter yes or no${RESET}";;
-            esac
-        done
-    fi  
 fi
 
-if [[ "$deployment" == "greenfield" ]]; then
-    PS3="${CYAN}Select desired deployment type: ${RESET}"
-    if [[ "$vmss_enabled" == "false" ]]; then
-        dtypes=(
-            "Deploy 1 Cloud Connector in a new Resource Group and VNet"
-            "Deploy 1 Cloud Connector in a new Resource Group and VNet w/ Private DNS for ZPA"
-            "Deploy multiple Cloud Connectors w/ Load Balancer in a new Resource Group and VNet"
-            "Deploy multiple Cloud Connectors w/ Load Balancer in a new Resource Group and VNet w/ Private DNS for ZPA"
-            "Deploy a new Resource Group and VNet only - No Cloud Connector resources"  
-        )
-        select greenfield_type in "${dtypes[@]}"
+if [[ "$oper" == "up" ]]; then
+    if [[ -e ./.zsecrc ]]; then
+        echo "${YELLOW}Existing deployment configuration file identified...${RESET}"
+        # initialize environment variables
+        . ./.zsecrc
+        echo "Refreshing Deployment Type: ${GREEN}$dtype${RESET}..." 
+    else #Prompt for deployment selection
+        PS3="${CYAN}Select desired deployment: ${RESET}"
+        deployments=("greenfield - Recommended for isolated test/POV deployments. Creates new network infrastructure, test workloads, and a public jump host" "brownfield - Recommended for prod deployments. Bring-your-own existing network infrastructure customizations + no workload/bastion creation")
+        select deployment in "${deployments[@]}"
         do
             case $REPLY in
                 1)
-                    echo "Deployment type base_1cc selected..."
-                    dtype=base_1cc
-                    break
-                    ;;
+                    echo "${GREEN}Greenfield deployment selected...${RESET}"
+                    echo "${YELLOW}**Caution** These deployments include test workloads and publicly accessible jump hosts and are intended primarily for lab/test environments${RESET}"
+                    echo ""
+                    deployment=greenfield
+                break
+                ;;
                 2)
-                    echo "Deployment type base_1cc_zpa selected..."
-                    dtype=base_1cc_zpa
-                    break
-                    ;;
-                3)
-                    echo "Deployment type base_cc_lb selected..."
-                    dtype=base_cc_lb
-                    break
-                    ;;
-                4)
-                    echo "Deployment type base_cc_lb_zpa selected..."
-                    dtype=base_cc_lb_zpa
-                    break
-                    ;;
-                5)
-                    echo "Deployment type base selected..."
-                    dtype=base
-                    break
-                    ;;
+                    echo "${GREEN}Brownfield deployment selected...${RESET}"
+                    deployment=brownfield
+                break
+                ;;
                 *) 
                     echo "${RED}Invalid response. Please enter a number selection${RESET}"
             esac
         done
-    elif [[ "$vmss_enabled" == "true" ]]; then
-        dtypes=(
-            "Deploy Virtual Machine Scale Set of Cloud Connectors w/ Load Balancer in a new Resource Group and VNet"
-            "Deploy Virtual Machine Scale Set of Cloud Connectors w/ Load Balancer in a new Resource Group and VNet w/ Private DNS for ZPA"
-        )
-        select greenfield_type in "${dtypes[@]}"
-        do
-            case $REPLY in
-                1)
-                    echo "Deployment type base_cc_vmss selected..."
-                    dtype=base_cc_vmss
-                    break
-                    ;;
-                2)
-                    echo "Deployment type base_cc_vmss_zpa selected..."
-                    dtype=base_cc_vmss_zpa
-                    break
-                    ;;
-                *) 
-                    echo "${RED}Invalid response. Please enter a number selection${RESET}"
-            esac
-        done
+        
+        if [[ "$zscaler_cloud" == "zscalerten.net" ]]; then
+            echo "${YELLOW}Zscalerten does not currently support Auto Scaling VMSS. Proceeding with standard deployment options...${RESET}"
+            if [[ "$deployment" == "greenfield" ]]; then 
+                vmss_enabled=false
+            elif [[ "$deployment" == "brownfield" ]]; then
+                echo "${GREEN}Proceeding with brownfield manual scaling with load balancer configuration...${RESET}"
+                vmss_enabled=false
+                #implicitly set dtype as cc_lb for brownfield + no vmss
+                dtype=cc_lb
+            fi
+        else
+            while true; do
+                read -r -p "${CYAN}Deploy Cloud Connectors in Auto Scaling VMSS? [yes/no]: ${RESET}" response
+                case $response in 
+                yes|y )
+                    if [[ "$deployment" == "greenfield" ]]; then 
+                        echo "${GREEN}Proceeding with greenfield Virtual Machine Scale Sets configuration...${RESET}"
+                        vmss_enabled=true
+                    elif [[ "$deployment" == "brownfield" ]]; then
+                        echo "${GREEN}Proceeding with brownfield Virtual Machine Scale Sets configuration...${RESET}"
+                        vmss_enabled=true
+                        #implicitly set dtype as cc_vmss for brownfield + vmss
+                        dtype=cc_vmss
+                    fi
+                break
+                ;;
+                no|n )
+                    if [[ "$deployment" == "greenfield" ]]; then 
+                        echo "${GREEN}Proceeding with greenfield manual scaling configuration...${RESET}"
+                        vmss_enabled=false
+                    elif [[ "$deployment" == "brownfield" ]]; then
+                        echo "${GREEN}Proceeding with brownfield manual scaling with load balancer configuration...${RESET}"
+                        vmss_enabled=false
+                        #implicitly set dtype as cc_lb for brownfield + no vmss
+                        dtype=cc_lb
+                    fi
+                break
+                ;;
+                    * ) echo "${RED}Invalid response. Please enter yes or no${RESET}";;
+                esac
+            done
+        fi
+    fi      
+
+    if [[ "$deployment" == "greenfield" ]]; then
+        PS3="${CYAN}Select desired deployment type: ${RESET}"
+        if [[ "$vmss_enabled" == "false" ]]; then
+            dtypes=(
+                "Deploy 1 Cloud Connector in a new Resource Group and VNet"
+                "Deploy 1 Cloud Connector in a new Resource Group and VNet w/ Private DNS for ZPA"
+                "Deploy multiple Cloud Connectors w/ Load Balancer in a new Resource Group and VNet"
+                "Deploy multiple Cloud Connectors w/ Load Balancer in a new Resource Group and VNet w/ Private DNS for ZPA"
+                "Deploy a new Resource Group and VNet only - No Cloud Connector resources"  
+            )
+            select greenfield_type in "${dtypes[@]}"
+            do
+                case $REPLY in
+                    1)
+                        echo "Deployment type base_1cc selected..."
+                        dtype=base_1cc
+                        break
+                        ;;
+                    2)
+                        echo "Deployment type base_1cc_zpa selected..."
+                        dtype=base_1cc_zpa
+                        break
+                        ;;
+                    3)
+                        echo "Deployment type base_cc_lb selected..."
+                        dtype=base_cc_lb
+                        break
+                        ;;
+                    4)
+                        echo "Deployment type base_cc_lb_zpa selected..."
+                        dtype=base_cc_lb_zpa
+                        break
+                        ;;
+                    5)
+                        echo "Deployment type base selected..."
+                        dtype=base
+                        break
+                        ;;
+                    *) 
+                        echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                esac
+            done
+        elif [[ "$vmss_enabled" == "true" ]]; then
+            dtypes=(
+                "Deploy Virtual Machine Scale Set of Cloud Connectors w/ Load Balancer in a new Resource Group and VNet"
+                "Deploy Virtual Machine Scale Set of Cloud Connectors w/ Load Balancer in a new Resource Group and VNet w/ Private DNS for ZPA"
+            )
+            select greenfield_type in "${dtypes[@]}"
+            do
+                case $REPLY in
+                    1)
+                        echo "Deployment type base_cc_vmss selected..."
+                        dtype=base_cc_vmss
+                        break
+                        ;;
+                    2)
+                        echo "Deployment type base_cc_vmss_zpa selected..."
+                        dtype=base_cc_vmss_zpa
+                        break
+                        ;;
+                    *) 
+                        echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                esac
+            done
+        fi
+    else
+        dtype=$dtype
     fi
-else
-    dtype=$dtype
 fi
 
 echo "Discovering processor architecture..."

--- a/examples/zsec
+++ b/examples/zsec
@@ -843,10 +843,35 @@ first_run="yes"
                     echo "Setting security group rule to ${GREEN}$support_server_ip_default${RESET}"
                     echo "export TF_VAR_zssupport_server='$support_server_ip_default'" >> .zsecrc
                 else
-                    echo "Resolving remotesupport.$zscaler_cloud to IP for Network Security Group rule..."
-                    support_server_ip=$(dig +short remotesupport.$zscaler_cloud)
-                    echo "${GREEN}Outbound rule permitting TCP/12002 access to $support_server_ip will be created${RESET}"
-                    echo "export TF_VAR_zssupport_server='$support_server_ip'" >> .zsecrc
+                    dns_commands=(
+                        "dig +short remotesupport.$zscaler_cloud 2>/dev/null || true"
+                        "getent ahostsv4 remotesupport.$zscaler_cloud 2>/dev/null | awk '{print \$1}' | head -1 || true"
+                        "host remotesupport.$zscaler_cloud 2>/dev/null | awk '/has address/ { print \$4 ; exit }' || true"
+                        "nslookup remotesupport.$zscaler_cloud 2>/dev/null | awk '/^Address: / { print \$2 ; exit }' || true"
+                    )
+
+                    for command in "${dns_commands[@]}"; do
+                    support_server_ip=$(eval "$command")
+                        if [[ $support_server_ip =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                            echo "${GREEN}Outbound rule permitting TCP/12002 access to $support_server_ip will be created${RESET}"
+                            echo "export TF_VAR_zssupport_server='$support_server_ip'" >> .zsecrc
+                            break
+                        fi
+                    done
+
+                    if [[ $support_server_ip == '' ]]; then
+                        if [[ "$zscaler_cloud" == "zscalerten.net" ]]; then
+                            support_server_ip="136.226.24.62"
+                        elif [[ "$zscaler_cloud" == "zscalergov.net" ]]; then
+                            support_server_ip="136.226.16.141"
+                        else
+                            support_server_ip="199.168.148.101"
+                        fi
+                        echo "Unable to lookup ip for remotesupport.$zscaler_cloud. Defaulting to static mapping"
+                        echo "${GREEN}Outbound rule permitting TCP/12002 access to $support_server_ip will be created${RESET}"
+                        echo "${YELLOW}Caution: Verify that this IP is correct for your Zscaler Cloud $zscaler_cloud${RESET}"
+                        echo "export TF_VAR_zssupport_server='$support_server_ip'" >> .zsecrc
+                    fi
                 fi
             break
             ;;

--- a/modules/terraform-zscc-bastion-azure/README.md
+++ b/modules/terraform-zscc-bastion-azure/README.md
@@ -8,14 +8,14 @@ This module creates all Azure VM, NSG, and Public IP resources needed to deploy 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-bastion-azure/versions.tf
+++ b/modules/terraform-zscc-bastion-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-ccvm-azure/README.md
+++ b/modules/terraform-zscc-ccvm-azure/README.md
@@ -27,7 +27,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -35,7 +35,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-ccvm-azure/main.tf
+++ b/modules/terraform-zscc-ccvm-azure/main.tf
@@ -36,12 +36,12 @@ resource "azurerm_network_interface_security_group_association" "cc_mgmt_nic_ass
 # This interface becomes LB0 interface for Medium/Large Cloud Connector sizes
 ################################################################################
 resource "azurerm_network_interface" "cc_service_nic" {
-  count                         = var.cc_count
-  name                          = "${var.name_prefix}-ccvm-${count.index + 1}-fwd-nic-${var.resource_tag}"
-  location                      = var.location
-  resource_group_name           = var.resource_group
-  enable_ip_forwarding          = true
-  enable_accelerated_networking = var.accelerated_networking_enabled
+  count                          = var.cc_count
+  name                           = "${var.name_prefix}-ccvm-${count.index + 1}-fwd-nic-${var.resource_tag}"
+  location                       = var.location
+  resource_group_name            = var.resource_group
+  ip_forwarding_enabled          = true
+  accelerated_networking_enabled = var.accelerated_networking_enabled
 
   ip_configuration {
     name                          = "${var.name_prefix}-ccvm-fwd-nic-conf-${var.resource_tag}"

--- a/modules/terraform-zscc-ccvm-azure/versions.tf
+++ b/modules/terraform-zscc-ccvm-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-ccvmss-azure/README.md
+++ b/modules/terraform-zscc-ccvmss-azure/README.md
@@ -27,7 +27,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -35,7 +35,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-ccvmss-azure/versions.tf
+++ b/modules/terraform-zscc-ccvmss-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-function-app-azure/README.md
+++ b/modules/terraform-zscc-function-app-azure/README.md
@@ -8,14 +8,14 @@ This module provides the necessary resource creation and configuration parameter
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 
 ## Modules

--- a/modules/terraform-zscc-function-app-azure/versions.tf
+++ b/modules/terraform-zscc-function-app-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-identity-azure/README.md
+++ b/modules/terraform-zscc-identity-azure/README.md
@@ -8,13 +8,13 @@ This module takes name and resource group inputs of an existing User Managed Ide
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-identity-azure/versions.tf
+++ b/modules/terraform-zscc-identity-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-lb-azure/README.md
+++ b/modules/terraform-zscc-lb-azure/README.md
@@ -8,13 +8,13 @@ This module creates a Standard Load Balancer, backend addres pool, LB rules, and
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-lb-azure/versions.tf
+++ b/modules/terraform-zscc-lb-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-network-azure/README.md
+++ b/modules/terraform-zscc-network-azure/README.md
@@ -32,14 +32,14 @@ Subnets used for DNS resolver have the following limitations:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-network-azure/main.tf
+++ b/modules/terraform-zscc-network-azure/main.tf
@@ -151,7 +151,7 @@ resource "azurerm_route_table" "workload_rt" {
   location            = var.location
   resource_group_name = try(data.azurerm_resource_group.rg_selected[0].name, azurerm_resource_group.rg[0].name)
 
-  disable_bgp_route_propagation = true
+  bgp_route_propagation_enabled = false
 
   route {
     name                   = "default-route"
@@ -209,7 +209,7 @@ resource "azurerm_route_table" "private_dns_rt" {
   location            = var.location
   resource_group_name = try(data.azurerm_resource_group.rg_selected[0].name, azurerm_resource_group.rg[0].name)
 
-  disable_bgp_route_propagation = true
+  bgp_route_propagation_enabled = false
 
   route {
     name                   = "default-route"

--- a/modules/terraform-zscc-network-azure/versions.tf
+++ b/modules/terraform-zscc-network-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-nsg-azure/README.md
+++ b/modules/terraform-zscc-nsg-azure/README.md
@@ -8,13 +8,13 @@ This module can be used to create default Management and Service interface NSG r
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-nsg-azure/versions.tf
+++ b/modules/terraform-zscc-nsg-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-private-dns-azure/README.md
+++ b/modules/terraform-zscc-private-dns-azure/README.md
@@ -56,13 +56,13 @@ Subnets used for DNS resolver have the following limitations:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-private-dns-azure/versions.tf
+++ b/modules/terraform-zscc-private-dns-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-workload-azure/README.md
+++ b/modules/terraform-zscc-workload-azure/README.md
@@ -8,14 +8,14 @@ This module creates all Azure VM and NSG resources needed to deploy test workloa
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46, <= 3.116 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.74 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.46, <= 3.116 |
 
 ## Modules
 

--- a/modules/terraform-zscc-workload-azure/versions.tf
+++ b/modules/terraform-zscc-workload-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.46, <= 3.74"
+      version = ">= 3.46, <= 3.116"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
BUG FIXES:
* AzureRM Provider version bump to 3.116.x default to address provider: skip registration for resource providers that are unavailable
* refactor: update Azure deprecated arguments:
    - azurerm_network_interface: enable_ip_forwarding change to ip_forwarding_enabled and enable_accelerated_networking to accelerated_networking_enabled
    - azurerm_route_table: disable_bgp_route_propagation (default true) change to bgp_route_propagation_enabled (default false)

ENHANCEMENTS:
* zsec support server lookup resiliency improvements