### PR TITLE
app service plan sku selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 * refactor: **support for future features** add base64 encoded user_data to VM and VMSS UserData attribute. CustomData will still be utilized until a future VHD release. At that time, it will remain as a secondary fallback to preferred UserData.
 * refactor: include ssh_config generation with auto mapping all workload/cc instances for base/greenfield deployments
 * refactor: change base/greenfield workload and bastion virtual machines from CentOS 7.5 to AlmaLinux 9
+* add: variable asp_sku_name for VMSS Deployments in regions that do not support Flex Consumption App Service Plan
 
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.7.0 (March 10, 2025)
+## v0.7.0 (March 14, 2025)
 
 FEATURES:
 * New Azure Region supported by Cloud Connector: Spain Central

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED (TBD)
+ENHANCEMENTS:
+* add: variable asp_sku_name for VMSS Deployments in regions that do not support Flex Consumption App Service Plan
+
 ## v0.7.0 (March 14, 2025)
 
 FEATURES:
@@ -7,7 +11,6 @@ ENHANCEMENTS:
 * refactor: **support for future features** add base64 encoded user_data to VM and VMSS UserData attribute. CustomData will still be utilized until a future VHD release. At that time, it will remain as a secondary fallback to preferred UserData.
 * refactor: include ssh_config generation with auto mapping all workload/cc instances for base/greenfield deployments
 * refactor: change base/greenfield workload and bastion virtual machines from CentOS 7.5 to AlmaLinux 9
-* add: variable asp_sku_name for VMSS Deployments in regions that do not support Flex Consumption App Service Plan
 
 
 BUG FIXES:

--- a/examples/base_cc_vmss/README.md
+++ b/examples/base_cc_vmss/README.md
@@ -266,6 +266,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 |------|-------------|------|---------|:--------:|
 | <a name="input_accelerated_networking_enabled"></a> [accelerated\_networking\_enabled](#input\_accelerated\_networking\_enabled) | Enable/Disable accelerated networking support on all Cloud Connector service interfaces | `bool` | `true` | no |
 | <a name="input_arm_location"></a> [arm\_location](#input\_arm\_location) | The Azure Region where resources are to be deployed | `string` | `"westus2"` | no |
+| <a name="input_asp_sku_name"></a> [asp\_sku\_name](#input\_asp\_sku\_name) | SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region | `string` | `"Y1"` | no |
 | <a name="input_azure_vault_url"></a> [azure\_vault\_url](#input\_azure\_vault\_url) | Azure Vault URL | `string` | n/a | yes |
 | <a name="input_bastion_nsg_source_prefix"></a> [bastion\_nsg\_source\_prefix](#input\_bastion\_nsg\_source\_prefix) | user input for locking down SSH access to bastion to a specific IP or CIDR range | `string` | `"*"` | no |
 | <a name="input_cc_subnets"></a> [cc\_subnets](#input\_cc\_subnets) | Cloud Connector Subnets to create in VNet. This is only required if you want to override the default subnets that this code creates via network\_address\_space variable. | `list(string)` | `null` | no |

--- a/examples/base_cc_vmss/main.tf
+++ b/examples/base_cc_vmss/main.tf
@@ -193,6 +193,7 @@ module "cc_functionapp" {
   existing_log_analytics_workspace_id = var.existing_log_analytics_workspace_id
   run_manual_sync                     = var.run_manual_sync
   path_to_scripts                     = coalesce(var.path_to_scripts, "../../scripts")
+  asp_sku_name                        = var.asp_sku_name
 }
 
 ################################################################################

--- a/examples/base_cc_vmss/terraform.tfvars
+++ b/examples/base_cc_vmss/terraform.tfvars
@@ -202,3 +202,11 @@
 # Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
 
 #function_app_managed_identity_rg                  = "function_rg_1"
+
+# Function App uses Azure App Service Plan for hosting. Zscaler recommends leaving the default (Y1 / Flex Consumption plan), but this
+# is not available in all Azure regions. If you cannot use Y1 and you do not require VNet Integration, then choose B1. If you do need
+# VNet Integration, then choose EP1.
+
+#asp_sku_name                                      = "Y1"
+#asp_sku_name                                      = "B1"
+#asp_sku_name                                      = "EP1"

--- a/examples/base_cc_vmss/variables.tf
+++ b/examples/base_cc_vmss/variables.tf
@@ -385,3 +385,18 @@ variable "path_to_scripts" {
   description = "Path to script_directory"
   default     = ""
 }
+
+variable "asp_sku_name" {
+  type        = string
+  description = "SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region"
+  default     = "Y1"
+  validation {
+    condition = (
+      var.asp_sku_name == "Y1" ||
+      var.asp_sku_name == "FC1" ||
+      var.asp_sku_name == "EP1" ||
+      var.asp_sku_name == "B1"
+    )
+    error_message = "Input asp_sku_name selected is not a valid/approved SKU Name."
+  }
+}

--- a/examples/base_cc_vmss_zpa/README.md
+++ b/examples/base_cc_vmss_zpa/README.md
@@ -256,6 +256,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 |------|-------------|------|---------|:--------:|
 | <a name="input_accelerated_networking_enabled"></a> [accelerated\_networking\_enabled](#input\_accelerated\_networking\_enabled) | Enable/Disable accelerated networking support on all Cloud Connector service interfaces | `bool` | `true` | no |
 | <a name="input_arm_location"></a> [arm\_location](#input\_arm\_location) | The Azure Region where resources are to be deployed | `string` | `"westus2"` | no |
+| <a name="input_asp_sku_name"></a> [asp\_sku\_name](#input\_asp\_sku\_name) | SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region | `string` | `"Y1"` | no |
 | <a name="input_azure_vault_url"></a> [azure\_vault\_url](#input\_azure\_vault\_url) | Azure Vault URL | `string` | n/a | yes |
 | <a name="input_bastion_nsg_source_prefix"></a> [bastion\_nsg\_source\_prefix](#input\_bastion\_nsg\_source\_prefix) | user input for locking down SSH access to bastion to a specific IP or CIDR range | `string` | `"*"` | no |
 | <a name="input_cc_subnets"></a> [cc\_subnets](#input\_cc\_subnets) | Cloud Connector Subnets to create in VNet. This is only required if you want to override the default subnets that this code creates via network\_address\_space variable. | `list(string)` | `null` | no |

--- a/examples/base_cc_vmss_zpa/main.tf
+++ b/examples/base_cc_vmss_zpa/main.tf
@@ -195,6 +195,7 @@ module "cc_functionapp" {
   existing_log_analytics_workspace_id = var.existing_log_analytics_workspace_id
   run_manual_sync                     = var.run_manual_sync
   path_to_scripts                     = coalesce(var.path_to_scripts, "../../scripts")
+  asp_sku_name                        = var.asp_sku_name
 }
 
 ################################################################################

--- a/examples/base_cc_vmss_zpa/terraform.tfvars
+++ b/examples/base_cc_vmss_zpa/terraform.tfvars
@@ -225,3 +225,11 @@
 # Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
 
 #function_app_managed_identity_rg                  = "function_rg_1"
+
+# Function App uses Azure App Service Plan for hosting. Zscaler recommends leaving the default (Y1 / Flex Consumption plan), but this
+# is not available in all Azure regions. If you cannot use Y1 and you do not require VNet Integration, then choose B1. If you do need
+# VNet Integration, then choose EP1.
+
+#asp_sku_name                                      = "Y1"
+#asp_sku_name                                      = "B1"
+#asp_sku_name                                      = "EP1"

--- a/examples/base_cc_vmss_zpa/variables.tf
+++ b/examples/base_cc_vmss_zpa/variables.tf
@@ -410,3 +410,18 @@ variable "path_to_scripts" {
   description = "Path to script_directory"
   default     = ""
 }
+
+variable "asp_sku_name" {
+  type        = string
+  description = "SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region"
+  default     = "Y1"
+  validation {
+    condition = (
+      var.asp_sku_name == "Y1" ||
+      var.asp_sku_name == "FC1" ||
+      var.asp_sku_name == "EP1" ||
+      var.asp_sku_name == "B1"
+    )
+    error_message = "Input asp_sku_name selected is not a valid/approved SKU Name."
+  }
+}

--- a/examples/cc_vmss/README.md
+++ b/examples/cc_vmss/README.md
@@ -253,6 +253,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 |------|-------------|------|---------|:--------:|
 | <a name="input_accelerated_networking_enabled"></a> [accelerated\_networking\_enabled](#input\_accelerated\_networking\_enabled) | Enable/Disable accelerated networking support on all Cloud Connector service interfaces | `bool` | `true` | no |
 | <a name="input_arm_location"></a> [arm\_location](#input\_arm\_location) | The Azure Region where resources are to be deployed | `string` | `"westus2"` | no |
+| <a name="input_asp_sku_name"></a> [asp\_sku\_name](#input\_asp\_sku\_name) | SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region | `string` | `"Y1"` | no |
 | <a name="input_azure_vault_url"></a> [azure\_vault\_url](#input\_azure\_vault\_url) | Azure Vault URL | `string` | n/a | yes |
 | <a name="input_byo_mgmt_nsg_names"></a> [byo\_mgmt\_nsg\_names](#input\_byo\_mgmt\_nsg\_names) | Existing Management Network Security Group IDs for Cloud Connector VM association. This must be populated if byo\_nsg variable is true | `list(string)` | `null` | no |
 | <a name="input_byo_nat_gw_names"></a> [byo\_nat\_gw\_names](#input\_byo\_nat\_gw\_names) | User provided existing NAT Gateway resource names. This must be populated if byo\_nat\_gws variable is true | `list(string)` | `null` | no |

--- a/examples/cc_vmss/main.tf
+++ b/examples/cc_vmss/main.tf
@@ -173,6 +173,7 @@ module "cc_functionapp" {
   existing_log_analytics_workspace_id = var.existing_log_analytics_workspace_id
   run_manual_sync                     = var.run_manual_sync
   path_to_scripts                     = coalesce(var.path_to_scripts, "../../scripts")
+  asp_sku_name                        = var.asp_sku_name
 }
 
 ################################################################################

--- a/examples/cc_vmss/terraform.tfvars
+++ b/examples/cc_vmss/terraform.tfvars
@@ -328,3 +328,11 @@
 # Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
 
 #function_app_managed_identity_rg                  = "function_rg_1"
+
+# Function App uses Azure App Service Plan for hosting. Zscaler recommends leaving the default (Y1 / Flex Consumption plan), but this
+# is not available in all Azure regions. If you cannot use Y1 and you do not require VNet Integration, then choose B1. If you do need
+# VNet Integration, then choose EP1.
+
+#asp_sku_name                                      = "Y1"
+#asp_sku_name                                      = "B1"
+#asp_sku_name                                      = "EP1"

--- a/examples/cc_vmss/variables.tf
+++ b/examples/cc_vmss/variables.tf
@@ -364,6 +364,21 @@ variable "path_to_scripts" {
   default     = ""
 }
 
+variable "asp_sku_name" {
+  type        = string
+  description = "SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region"
+  default     = "Y1"
+  validation {
+    condition = (
+      var.asp_sku_name == "Y1" ||
+      var.asp_sku_name == "FC1" ||
+      var.asp_sku_name == "EP1" ||
+      var.asp_sku_name == "B1"
+    )
+    error_message = "Input asp_sku_name selected is not a valid/approved SKU Name."
+  }
+}
+
 # Azure Private DNS specific variables
 variable "zpa_enabled" {
   type        = bool

--- a/examples/zsec
+++ b/examples/zsec
@@ -1100,6 +1100,58 @@ first_run="yes"
                     * ) echo "${RED}Invalid response. Please enter yes or no${RESET}";;
                 esac
             done
+
+            asp_flex_consumption_supported_regions=(
+                "australiaeast"
+                "eastasia"
+                "eastus"
+                "eastus2"
+                "northeurope"
+                "southcentralus"
+                "southeastasia"
+                "swedencentral"
+                "uksouth"
+                "westus2"
+                "westus3"
+                )
+
+            # asp dynamic selection option
+            asp_all="Y1 B1 EP1"
+            asp_no_flex="B1 EP1"
+
+            # Select App Service Plan SKU for function app
+            PS3="${CYAN}Select App Service Plan SKU: ${RESET}"
+            
+            if [[ ${asp_flex_consumption_supported_regions[@]} =~ $azure_location ]]; then
+                #display options for flex consumption, basic, and premium
+                asp_sku_names=($asp_all)
+
+            else
+                # display only basic and premium options
+                asp_sku_names=($asp_no_flex)
+            fi
+            select asp_sku_name_selection in "${asp_sku_names[@]}"; 
+                do
+                    case $asp_sku_name_selection in
+                    Y1 )
+                        echo "SKU Name ${GREEN}$asp_sku_name_selection${RESET} selected..."
+                        echo "export TF_VAR_asp_sku_name='$asp_sku_name_selection'" >> .zsecrc
+                    break
+                    ;;
+                    B1 )
+                        echo "SKU Name ${GREEN}$asp_sku_name_selection${RESET} selected..."
+                        echo "export TF_VAR_asp_sku_name='$asp_sku_name_selection'" >> .zsecrc
+                    break
+                    ;;
+                    EP1 )
+                        echo "SKU Name ${GREEN}$asp_sku_name_selection${RESET} selected..."
+                        echo "export TF_VAR_asp_sku_name='$asp_sku_name_selection'" >> .zsecrc
+                    break
+                    ;;
+                    *) 
+                        echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                    esac
+                done
              
             # Azure Function Public URL
             echo "By default, Terraform will upload the Zscaler CC Azure Function Zip to this Storage Account Blob for Function App retrieval"

--- a/modules/terraform-zscc-function-app-azure/README.md
+++ b/modules/terraform-zscc-function-app-azure/README.md
@@ -1,12 +1,19 @@
-# Zscaler Cloud Connector / Azure Function App Module
+# Zscaler Cloud Connector VMSS / Azure Function App Module
 
 This module provides the necessary resource creation and configuration parameters to deploy the Zscaler generated Azure Function App and dependencies required for management and health monitoring of Cloud Connectors deployed in a Virtual Machine Scale Set (VMSS). Recommended configuration includes the creation of a new Azure Storage Account for Function App zip file upload/storage and runtime. For full functionality, a dedicate App Service Plan and Application Insights resource are required for custom metric ingestion and processing.
 
 | Function ZIP Version | SHA256 Hash | GitHub Release Date/Tag |
 | ----------- | --------| ------------ |
-| 1.0.1| aed981cf32c7cf62623f3195b8e1315afb570b43d451a0ba0e782e4ba0d828dd | 12/06/2024 - [v0.6.2](https://github.com/zscaler/terraform-azurerm-cloud-connector-modules/releases/tag/v0.6.2) |
+| 1.0.1*| aed981cf32c7cf62623f3195b8e1315afb570b43d451a0ba0e782e4ba0d828dd | 12/06/2024 - [v0.6.2](https://github.com/zscaler/terraform-azurerm-cloud-connector-modules/releases/tag/v0.6.2) |
 | 1.0.0 | 8de1144256df20f970f9c382c001bad14d2de1407a9d8b7a6edd3a6c5143d3bc | 09/05/2024 - [v0.6.0](https://github.com/zscaler/terraform-azurerm-cloud-connector-modules/releases/tag/v0.6.0) |
 
+*Zscaler recommends always running the latest Function App ZIP Version
+
+## Caveats/Considerations
+Azure Function App is deployed with App Service Plan as its [hosting option](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale). The recommended hosting option is Flex Consumption Plan (SKU Name: Y1), but there are some limitations with this.
+
+1. Recommended Flex Consumption plan and/or Consumption plan is not available for use in all Azure Regions. See [Product Availability by Region](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/table) and search for Functions.
+2. Only Flex Consumption supports [Virtual Network Integration](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options?tabs=azure-portal#virtual-network-integration). If this plan is not available in your region, and you require VNet Integration, you will need to upgrade to Elastic Premium (EP1) plan.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -48,6 +55,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_asp_sku_name"></a> [asp\_sku\_name](#input\_asp\_sku\_name) | SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region | `string` | `"Y1"` | no |
 | <a name="input_azure_vault_url"></a> [azure\_vault\_url](#input\_azure\_vault\_url) | Azure Vault URL | `string` | n/a | yes |
 | <a name="input_cc_vm_prov_url"></a> [cc\_vm\_prov\_url](#input\_cc\_vm\_prov\_url) | Zscaler Cloud Connector Provisioning URL | `string` | n/a | yes |
 | <a name="input_existing_log_analytics_workspace"></a> [existing\_log\_analytics\_workspace](#input\_existing\_log\_analytics\_workspace) | Set to True if you wish to use an existing Log Analytics Workspace to associate with the AppInsights Instance. Default is false meaning Terraform module will create a new one | `bool` | `false` | no |

--- a/modules/terraform-zscc-function-app-azure/main.tf
+++ b/modules/terraform-zscc-function-app-azure/main.tf
@@ -49,7 +49,7 @@ resource "azurerm_service_plan" "vmss_orchestration_app_service_plan" {
   resource_group_name = var.resource_group
   location            = var.location
   os_type             = "Linux"
-  sku_name            = "Y1"
+  sku_name            = var.asp_sku_name
 
   tags = var.global_tags
 }

--- a/modules/terraform-zscc-function-app-azure/variables.tf
+++ b/modules/terraform-zscc-function-app-azure/variables.tf
@@ -122,3 +122,18 @@ variable "path_to_scripts" {
   description = "Path to script_directory"
   default     = ""
 }
+
+variable "asp_sku_name" {
+  type        = string
+  description = "SKU Name for the App Service Plan. Recommended Y1 (flex consumption) for function app unless not supported by Azure region"
+  default     = "Y1"
+  validation {
+    condition = (
+      var.asp_sku_name == "Y1" ||
+      var.asp_sku_name == "FC1" ||
+      var.asp_sku_name == "EP1" ||
+      var.asp_sku_name == "B1"
+    )
+    error_message = "Input asp_sku_name selected is not a valid/approved SKU Name."
+  }
+}


### PR DESCRIPTION
only the following Azure regions currently support flex consumption plan for function apps
asp_flex_consumption_supported_regions=(
                "australiaeast"
                "eastasia"
                "eastus"
                "eastus2"
                "northeurope"
                "southcentralus"
                "southeastasia"
                "swedencentral"
                "uksouth"
                "westus2"
                "westus3"
                )

for other regions, we can't use "Y1" app service plan SKU. Adding variable and logic to support B1 and EP1 as required.