### PR TITLE
ZTW-7154 Add dependencies for configuring VWAN Hub BGP connection

### DIFF
--- a/examples/base_1cc/main.tf
+++ b/examples/base_1cc/main.tf
@@ -61,6 +61,8 @@ module "network" {
   workloads_enabled     = true
   bastion_enabled       = true
   lb_enabled            = var.lb_enabled
+  vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
 }
 
 
@@ -112,6 +114,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_vm.service_ip[0]}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/base_1cc/variables.tf
+++ b/examples/base_1cc/variables.tf
@@ -225,3 +225,15 @@ variable "zssupport_server" {
   description = "destination IP address of Zscaler Support access server. IP resolution of remotesupport.<zscaler_customer_cloud>.net"
   default     = "199.168.148.101" #for commercial clouds
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
+  default     = ""
+}

--- a/examples/base_1cc_zpa/main.tf
+++ b/examples/base_1cc_zpa/main.tf
@@ -63,6 +63,8 @@ module "network" {
   bastion_enabled       = true
   lb_enabled            = var.lb_enabled
   zpa_enabled           = var.zpa_enabled
+  vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
 }
 
 
@@ -114,6 +116,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_vm.service_ip[0]}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/base_1cc_zpa/variables.tf
+++ b/examples/base_1cc_zpa/variables.tf
@@ -249,3 +249,15 @@ variable "target_address" {
   description = "Azure DNS queries will be conditionally forwarded to these target IP addresses. Default are a pair of Zscaler Global VIP addresses"
   default     = ["185.46.212.88", "185.46.212.89"]
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
+  default     = ""
+}

--- a/examples/base_cc_lb/main.tf
+++ b/examples/base_cc_lb/main.tf
@@ -117,7 +117,7 @@ AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id
 [BGPCONFIG]
 LB_VIP=${module.cc_lb.lb_ip}
 VWAN_HUB_ID=${var.vwan_hub_id}
-VNET_CONNECTION_NAME=${var.vnet_connection_name}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/base_cc_lb/main.tf
+++ b/examples/base_cc_lb/main.tf
@@ -62,6 +62,7 @@ module "network" {
   bastion_enabled       = true
   lb_enabled            = var.lb_enabled
   vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
 }
 
 

--- a/examples/base_cc_lb/main.tf
+++ b/examples/base_cc_lb/main.tf
@@ -61,6 +61,7 @@ module "network" {
   workloads_enabled     = true
   bastion_enabled       = true
   lb_enabled            = var.lb_enabled
+  vwan_hub_id           = var.vwan_hub_id
 }
 
 
@@ -112,6 +113,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_lb.lb_ip}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_NAME=${var.vnet_connection_name}
 USERDATA
 }
 

--- a/examples/base_cc_lb/variables.tf
+++ b/examples/base_cc_lb/variables.tf
@@ -266,12 +266,12 @@ variable "zssupport_server" {
 
 variable "vwan_hub_id" {
   type        = string
-  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
   default     = ""
 }
 
 variable "vnet_connection_name" {
   type        = string
-  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
   default     = ""
 }

--- a/examples/base_cc_lb/variables.tf
+++ b/examples/base_cc_lb/variables.tf
@@ -263,3 +263,15 @@ variable "zssupport_server" {
   description = "destination IP address of Zscaler Support access server. IP resolution of remotesupport.<zscaler_customer_cloud>.net"
   default     = "199.168.148.101" #for commercial clouds
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  default     = "zscaler-vnet-vwan-connection"
+}

--- a/examples/base_cc_lb/variables.tf
+++ b/examples/base_cc_lb/variables.tf
@@ -273,5 +273,5 @@ variable "vwan_hub_id" {
 variable "vnet_connection_name" {
   type        = string
   description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
-  default     = "zscaler-vnet-vwan-connection"
+  default     = ""
 }

--- a/examples/base_cc_lb_zpa/main.tf
+++ b/examples/base_cc_lb_zpa/main.tf
@@ -119,7 +119,7 @@ AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id
 [BGPCONFIG]
 LB_VIP=${module.cc_lb.lb_ip}
 VWAN_HUB_ID=${var.vwan_hub_id}
-VNET_CONNECTION_NAME=${var.vnet_connection_name}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/base_cc_lb_zpa/main.tf
+++ b/examples/base_cc_lb_zpa/main.tf
@@ -63,6 +63,7 @@ module "network" {
   bastion_enabled       = true
   lb_enabled            = var.lb_enabled
   zpa_enabled           = var.zpa_enabled
+  vwan_hub_id           = var.vwan_hub_id
 }
 
 
@@ -114,6 +115,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_lb.lb_ip}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_NAME=${var.vnet_connection_name}
 USERDATA
 }
 

--- a/examples/base_cc_lb_zpa/main.tf
+++ b/examples/base_cc_lb_zpa/main.tf
@@ -64,6 +64,7 @@ module "network" {
   lb_enabled            = var.lb_enabled
   zpa_enabled           = var.zpa_enabled
   vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
 }
 
 

--- a/examples/base_cc_lb_zpa/variables.tf
+++ b/examples/base_cc_lb_zpa/variables.tf
@@ -291,13 +291,13 @@ variable "target_address" {
 
 variable "vwan_hub_id" {
   type        = string
-  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
   default     = ""
 }
 
 variable "vnet_connection_name" {
   type        = string
-  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
   default     = ""
 }
 

--- a/examples/base_cc_lb_zpa/variables.tf
+++ b/examples/base_cc_lb_zpa/variables.tf
@@ -298,6 +298,6 @@ variable "vwan_hub_id" {
 variable "vnet_connection_name" {
   type        = string
   description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
-  default     = "zscaler-vnet-vwan-connection"
+  default     = ""
 }
 

--- a/examples/base_cc_lb_zpa/variables.tf
+++ b/examples/base_cc_lb_zpa/variables.tf
@@ -288,3 +288,16 @@ variable "target_address" {
   description = "Azure DNS queries will be conditionally forwarded to these target IP addresses. Default are a pair of Zscaler Global VIP addresses"
   default     = ["185.46.212.88", "185.46.212.89"]
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  default     = "zscaler-vnet-vwan-connection"
+}
+

--- a/examples/base_cc_vmss/main.tf
+++ b/examples/base_cc_vmss/main.tf
@@ -118,7 +118,7 @@ AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id
 [BGPCONFIG]
 LB_VIP=${module.cc_lb.lb_ip}
 VWAN_HUB_ID=${var.vwan_hub_id}
-VNET_CONNECTION_NAME=${var.vnet_connection_name}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/base_cc_vmss/main.tf
+++ b/examples/base_cc_vmss/main.tf
@@ -60,6 +60,8 @@ module "network" {
   lb_frontend_ip        = module.cc_lb.lb_ip
   workloads_enabled     = true
   bastion_enabled       = true
+  vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
 }
 
 
@@ -113,6 +115,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_lb.lb_ip}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_NAME=${var.vnet_connection_name}
 USERDATA
 }
 

--- a/examples/base_cc_vmss/variables.tf
+++ b/examples/base_cc_vmss/variables.tf
@@ -388,12 +388,12 @@ variable "path_to_scripts" {
 
 variable "vwan_hub_id" {
   type        = string
-  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
   default     = ""
 }
 
 variable "vnet_connection_name" {
   type        = string
-  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
   default     = ""
 }

--- a/examples/base_cc_vmss/variables.tf
+++ b/examples/base_cc_vmss/variables.tf
@@ -385,3 +385,15 @@ variable "path_to_scripts" {
   description = "Path to script_directory"
   default     = ""
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  default     = ""
+}

--- a/examples/base_cc_vmss_zpa/main.tf
+++ b/examples/base_cc_vmss_zpa/main.tf
@@ -120,7 +120,7 @@ AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id
 [BGPCONFIG]
 LB_VIP=${module.cc_lb.lb_ip}
 VWAN_HUB_ID=${var.vwan_hub_id}
-VNET_CONNECTION_NAME=${var.vnet_connection_name}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/base_cc_vmss_zpa/main.tf
+++ b/examples/base_cc_vmss_zpa/main.tf
@@ -62,6 +62,8 @@ module "network" {
   workloads_enabled     = true
   bastion_enabled       = true
   zpa_enabled           = var.zpa_enabled
+  vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
 }
 
 
@@ -115,6 +117,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_lb.lb_ip}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_NAME=${var.vnet_connection_name}
 USERDATA
 }
 

--- a/examples/base_cc_vmss_zpa/variables.tf
+++ b/examples/base_cc_vmss_zpa/variables.tf
@@ -413,12 +413,12 @@ variable "path_to_scripts" {
 
 variable "vwan_hub_id" {
   type        = string
-  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
   default     = ""
 }
 
 variable "vnet_connection_name" {
   type        = string
-  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
   default     = ""
 }

--- a/examples/base_cc_vmss_zpa/variables.tf
+++ b/examples/base_cc_vmss_zpa/variables.tf
@@ -410,3 +410,15 @@ variable "path_to_scripts" {
   description = "Path to script_directory"
   default     = ""
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  default     = ""
+}

--- a/examples/cc_lb/main.tf
+++ b/examples/cc_lb/main.tf
@@ -97,7 +97,7 @@ AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id
 [BGPCONFIG]
 LB_VIP=${module.cc_lb.lb_ip}
 VWAN_HUB_ID=${var.vwan_hub_id}
-VNET_CONNECTION_NAME=${var.vnet_connection_name}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/cc_lb/main.tf
+++ b/examples/cc_lb/main.tf
@@ -58,6 +58,8 @@ module "network" {
   zones                 = var.zones
   lb_frontend_ip        = module.cc_lb.lb_ip
   zpa_enabled           = var.zpa_enabled
+  vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
   #bring-your-own variables
   byo_rg                             = var.byo_rg
   byo_rg_name                        = var.byo_rg_name
@@ -92,6 +94,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_lb.lb_ip}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_NAME=${var.vnet_connection_name}
 USERDATA
 }
 

--- a/examples/cc_lb/variables.tf
+++ b/examples/cc_lb/variables.tf
@@ -376,12 +376,12 @@ variable "byo_service_nsg_names" {
 
 variable "vwan_hub_id" {
   type        = string
-  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
   default     = ""
 }
 
 variable "vnet_connection_name" {
   type        = string
-  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
   default     = ""
 }

--- a/examples/cc_lb/variables.tf
+++ b/examples/cc_lb/variables.tf
@@ -373,3 +373,15 @@ variable "byo_service_nsg_names" {
   description = "Existing Service Network Security Group ID for Cloud Connector VM association. This must be populated if byo_nsg variable is true"
   default     = null
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  default     = ""
+}

--- a/examples/cc_vmss/main.tf
+++ b/examples/cc_vmss/main.tf
@@ -98,7 +98,7 @@ AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id
 [BGPCONFIG]
 LB_VIP=${module.cc_lb.lb_ip}
 VWAN_HUB_ID=${var.vwan_hub_id}
-VNET_CONNECTION_NAME=${var.vnet_connection_name}
+VNET_CONNECTION_ID=${module.network.virtual_network_vwan_connection_id}
 USERDATA
 }
 

--- a/examples/cc_vmss/main.tf
+++ b/examples/cc_vmss/main.tf
@@ -58,6 +58,8 @@ module "network" {
   zones                 = var.zones
   lb_frontend_ip        = module.cc_lb.lb_ip
   zpa_enabled           = var.zpa_enabled
+  vwan_hub_id           = var.vwan_hub_id
+  vnet_connection_name  = var.vnet_connection_name
   #bring-your-own variables
   byo_rg                             = var.byo_rg
   byo_rg_name                        = var.byo_rg_name
@@ -93,6 +95,10 @@ CC_URL=${var.cc_vm_prov_url}
 AZURE_VAULT_URL=${var.azure_vault_url}
 HTTP_PROBE_PORT=${var.http_probe_port}
 AZURE_MANAGED_IDENTITY_CLIENT_ID=${module.cc_identity.managed_identity_client_id}
+[BGPCONFIG]
+LB_VIP=${module.cc_lb.lb_ip}
+VWAN_HUB_ID=${var.vwan_hub_id}
+VNET_CONNECTION_NAME=${var.vnet_connection_name}
 USERDATA
 }
 

--- a/examples/cc_vmss/variables.tf
+++ b/examples/cc_vmss/variables.tf
@@ -503,12 +503,12 @@ variable "byo_service_nsg_names" {
 
 variable "vwan_hub_id" {
   type        = string
-  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
   default     = ""
 }
 
 variable "vnet_connection_name" {
   type        = string
-  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
   default     = ""
 }

--- a/examples/cc_vmss/variables.tf
+++ b/examples/cc_vmss/variables.tf
@@ -500,3 +500,15 @@ variable "byo_service_nsg_names" {
   description = "Existing Service Network Security Group ID for Cloud Connector VM association. This must be populated if byo_nsg variable is true"
   default     = null
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  default     = ""
+}

--- a/examples/zsec
+++ b/examples/zsec
@@ -639,9 +639,12 @@ first_run="yes"
 
         read -r -p "${CYAN}Enter VWAN HUB ID that you would like to peer to [Default=""]: ${RESET}" vwan_hub_id
         echo "export TF_VAR_vwan_hub_id=${vwan_hub_id}" >> .zsecrc
-
-        read -r -p "${CYAN}Enter vnet connection name (Only if you would like Zscaler to create a VNET connection to the VWAN Hub [Default=""]): ${RESET}" vnet_connection_name
-        echo "export TF_VAR_vnet_connection_name=${vnet_connection_name}" >> .zsecrc
+        if [[ "$deployment" == "brownfield" && -n ${vwan_hub_id} ]]; then
+            read -r -p "${CYAN}Enter name of connection from vnet to vwan if it exists already [Default=""]): ${RESET}" vnet_connection_name
+	    if [[ -n ${vnet_connection_name} ]]; then
+		echo "export TF_VAR_vnet_connection_name=${vnet_connection_name}" >> .zsecrc
+            fi
+       fi
 
         az_supported_regions=["australiaeast","brazilsouth","canadacentral","centralindia","centralus","chinanorth3","eastasia","eastus","eastus2","francecentral","germanywestcentral","japaneast","koreacentral","northeurope","norwayeast","southafricanorth","southcentralus","southeastasia","spaincentral","swedencentral","switzerlandnorth","uaenorth","uksouth","westeurope","westus2","westus3","usgovvirginia"]
         if [[ ${az_supported_regions[*]} =~ $azure_location ]]; then

--- a/examples/zsec
+++ b/examples/zsec
@@ -637,6 +637,9 @@ first_run="yes"
             fi
         fi
 
+        read -r -p "${CYAN}Enter VWAN HUB ID that you would like to peer to [Default=""]: ${RESET}" vwan_hub_id
+        echo "export TF_VAR_vwan_hub_id=${vwan_hub_id}" >> .zsecrc
+
         az_supported_regions=["australiaeast","brazilsouth","canadacentral","centralindia","centralus","chinanorth3","eastasia","eastus","eastus2","francecentral","germanywestcentral","japaneast","koreacentral","northeurope","norwayeast","southafricanorth","southcentralus","southeastasia","spaincentral","swedencentral","switzerlandnorth","uaenorth","uksouth","westeurope","westus2","westus3","usgovvirginia"]
         if [[ ${az_supported_regions[*]} =~ $azure_location ]]; then
             echo "${GREEN}Azure region ${azure_location} supports Zones deployment...${RESET}"

--- a/examples/zsec
+++ b/examples/zsec
@@ -640,6 +640,9 @@ first_run="yes"
         read -r -p "${CYAN}Enter VWAN HUB ID that you would like to peer to [Default=""]: ${RESET}" vwan_hub_id
         echo "export TF_VAR_vwan_hub_id=${vwan_hub_id}" >> .zsecrc
 
+        read -r -p "${CYAN}Enter vnet connection name (Only if you would like Zscaler to create a VNET connection to the VWAN Hub [Default=""]): ${RESET}" vnet_connection_name
+        echo "export TF_VAR_vnet_connection_name=${vnet_connection_name}" >> .zsecrc
+
         az_supported_regions=["australiaeast","brazilsouth","canadacentral","centralindia","centralus","chinanorth3","eastasia","eastus","eastus2","francecentral","germanywestcentral","japaneast","koreacentral","northeurope","norwayeast","southafricanorth","southcentralus","southeastasia","spaincentral","swedencentral","switzerlandnorth","uaenorth","uksouth","westeurope","westus2","westus3","usgovvirginia"]
         if [[ ${az_supported_regions[*]} =~ $azure_location ]]; then
             echo "${GREEN}Azure region ${azure_location} supports Zones deployment...${RESET}"

--- a/modules/terraform-zscc-network-azure/main.tf
+++ b/modules/terraform-zscc-network-azure/main.tf
@@ -41,13 +41,28 @@ data "azurerm_virtual_network" "vnet_selected" {
   resource_group_name = var.byo_vnet_subnets_rg_name
 }
 
-resource "azurerm_virtual_hub_connection" "zscaler_vnet_to_vwan" {
-  count                     = var.vwan_hub_id != null && var.vwan_hub_id != "" && var.vnet_connection_name != "" ? 1 : 0
-  name                      = var.vnet_connection_name
+
+################################################################################
+# Virtual Network connection to VWAN Hub
+################################################################################
+locals {
+  virtual_hub_name = var.vwan_hub_id != null && var.vwan_hub_id != "" ? element(split("/", var.vwan_hub_id), length(split("/", var.vwan_hub_id)) - 1) : null
+}
+
+# Create VNET to VWAN Connection or reference existing
+resource "azurerm_virtual_hub_connection" "vnet_to_vwan" {
+  count                     = var.vwan_hub_id != null && var.vwan_hub_id != "" && (var.vnet_connection_name == null || var.vnet_connection_name == "") ? 1 : 0
+  name                      = "${var.name_prefix}-vnet-vwan-connection-${var.resource_tag}"
   virtual_hub_id            = var.vwan_hub_id
   remote_virtual_network_id = var.byo_vnet ? data.azurerm_virtual_network.vnet_selected[0].id : azurerm_virtual_network.vnet[0].id
 }
 
+data "azurerm_virtual_hub_connection" "vnet_to_vwan_selected" {
+  count               = var.vwan_hub_id != null && var.vwan_hub_id != "" && var.vnet_connection_name != null && var.vnet_connection_name != "" ? 1 : 0
+  name                = var.vwan_hub_id != null && var.vwan_hub_id != "" && var.vnet_connection_name != null && var.vnet_connection_name != "" ? var.vnet_connection_name : azurerm_virtual_hub_connection.vnet_to_vwan[0].name
+  resource_group_name = try(data.azurerm_resource_group.rg_selected[0].name, azurerm_resource_group.rg[0].name)
+  virtual_hub_name    = local.virtual_hub_name
+}
 
 ################################################################################
 # NAT Gateway

--- a/modules/terraform-zscc-network-azure/main.tf
+++ b/modules/terraform-zscc-network-azure/main.tf
@@ -41,6 +41,13 @@ data "azurerm_virtual_network" "vnet_selected" {
   resource_group_name = var.byo_vnet_subnets_rg_name
 }
 
+resource "azurerm_virtual_hub_connection" "zscaler_vnet_to_vwan" {
+  count                     = var.vwan_hub_id != null && var.vwan_hub_id != "" ? 1 : 0
+  name                      = var.vnet_connection_name
+  virtual_hub_id            = var.vwan_hub_id
+  remote_virtual_network_id = var.byo_vnet ? data.azurerm_virtual_network.vnet_selected[0].id : azurerm_virtual_network.vnet[0].id
+}
+
 
 ################################################################################
 # NAT Gateway

--- a/modules/terraform-zscc-network-azure/main.tf
+++ b/modules/terraform-zscc-network-azure/main.tf
@@ -42,7 +42,7 @@ data "azurerm_virtual_network" "vnet_selected" {
 }
 
 resource "azurerm_virtual_hub_connection" "zscaler_vnet_to_vwan" {
-  count                     = var.vwan_hub_id != null && var.vwan_hub_id != "" ? 1 : 0
+  count                     = var.vwan_hub_id != null && var.vwan_hub_id != "" && var.vnet_connection_name != "" ? 1 : 0
   name                      = var.vnet_connection_name
   virtual_hub_id            = var.vwan_hub_id
   remote_virtual_network_id = var.byo_vnet ? data.azurerm_virtual_network.vnet_selected[0].id : azurerm_virtual_network.vnet[0].id

--- a/modules/terraform-zscc-network-azure/outputs.tf
+++ b/modules/terraform-zscc-network-azure/outputs.tf
@@ -28,6 +28,11 @@ output "virtual_network_id" {
   value       = var.byo_vnet ? data.azurerm_virtual_network.vnet_selected[0].id : azurerm_virtual_network.vnet[0].id
 }
 
+output "virtual_network_vwan_connection_id" {
+  description = "ID of connection from Azure Virtual Network to Virtual WAN"
+  value       = var.vwan_hub_id != null && var.vwan_hub_id != "" ? (var.vnet_connection_name != null && var.vnet_connection_name != "" ? data.azurerm_virtual_hub_connection.vnet_to_vwan_selected[0].id : azurerm_virtual_hub_connection.vnet_to_vwan[0].id) : ""
+}
+
 output "private_dns_subnet_id" {
   description = "Private DNS Outbound Endpoint Subnet ID"
   value       = var.zpa_enabled ? azurerm_subnet.private_dns_subnet[0].id : ""

--- a/modules/terraform-zscc-network-azure/variables.tf
+++ b/modules/terraform-zscc-network-azure/variables.tf
@@ -213,12 +213,12 @@ variable "existing_nat_gw_subnet_association" {
 
 variable "vwan_hub_id" {
   type        = string
-  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  description = "VWAN Hub ID to which Security Spoke VNET will connect to"
   default     = ""
 }
 
 variable "vnet_connection_name" {
   type        = string
-  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  description = "Name of VNET connection from Security Spoke VNET to VWAN Hub"
   default     = ""
 }

--- a/modules/terraform-zscc-network-azure/variables.tf
+++ b/modules/terraform-zscc-network-azure/variables.tf
@@ -220,5 +220,5 @@ variable "vwan_hub_id" {
 variable "vnet_connection_name" {
   type        = string
   description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
-  default     = "zscaler-vnet-vwan-connection"
+  default     = ""
 }

--- a/modules/terraform-zscc-network-azure/variables.tf
+++ b/modules/terraform-zscc-network-azure/variables.tf
@@ -210,3 +210,15 @@ variable "existing_nat_gw_subnet_association" {
   description = "Set this to true only if both byo_nat_gws and byo_subnets variables are true. this implies that there are already NAT Gateway resources associated to subnets where Cloud Connectors are being deployed to"
   default     = false
 }
+
+variable "vwan_hub_id" {
+  type        = string
+  description = "VWAN Hub ID to which Zscaler Spoke VNET will connect to"
+  default     = ""
+}
+
+variable "vnet_connection_name" {
+  type        = string
+  description = "Name of VNET connection from Zscaler Spoke VNET to VWAN Hub"
+  default     = "zscaler-vnet-vwan-connection"
+}


### PR DESCRIPTION
from Janus

Testing Details:

Deployed it in "EC Development"  (c54189e1-079f-42e0-95fb-b591bccff398) Azure

Connected to "vj-devtest-vwan"

Userdata:


>BGPCONFIG:
    lb_vip: 10.1.200.4
    vnet_connection_id: /subscriptions/c54189e1-079f-42e0-95fb-b591bccff398/resourceGroups/vj-rg-eastus2/providers/Microsoft.Network/virtualHubs/vj-devtest-vwan-hub/hubVirtualNetworkConnections/zscc-vnet-vwan-connection-x00gjj3o
    vwan_hub_id: /subscriptions/c54189e1-079f-42e0-95fb-b591bccff398/resourceGroups/vj-rg-eastus2/providers/Microsoft.Network/virtualHubs/vj-devtest-vwan-hub
ZSCALER:
    azure_managed_identity_client_id: 9d425378-a145-44ce-917f-c56175e1bc3e
    azure_vault_url: https://vjzscalerkv.vault.azure.net/
    cc_url: connector.zsdevel.net/api/v1/provUrl?name=vwanhubtest-2
    http_probe_port: '50000'
> 


Summary of the changes is:
1. zsec bash script is changed to accept "VWAN Hub ID" as a parameter and VNET connection name as a parameter. VNET Connection name is optional - if not provided, Zscaler will create a VNET connection to the VWAN Hub. If provided, it will be used.
2. All the deployment options are changed to accept the above 2 variables as parameters and pass them as part of USERDATA to the CC VMs.
3. The LB IP is also read from the CC_LB module and passed to the CC VM as part of the USERDATA
4. The network module will create a virtual_hub_connection (from security vnet to vwan) if the VWAN Hub ID is provided and VNET connection name is not provided.
5. The network module will reuse an existing virtual_hub_connection (from security vnet to vwan) if the VWAN Hub ID is provided and VNET connection name is provided.