### PR TITLE
Add tags to resources missing them

### DIFF
--- a/modules/terraform-zscc-ccvmss-azure/main.tf
+++ b/modules/terraform-zscc-ccvmss-azure/main.tf
@@ -247,4 +247,6 @@ resource "azurerm_monitor_autoscale_setting" "vmss_autoscale_setting" {
       }
     }
   }
+
+  tags = var.global_tags
 }

--- a/modules/terraform-zscc-function-app-azure/main.tf
+++ b/modules/terraform-zscc-function-app-azure/main.tf
@@ -15,6 +15,8 @@ resource "azurerm_storage_account" "cc_function_storage_account" {
   location                 = var.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  tags = var.global_tags
 }
 
 # Or use an existing storage account


### PR DESCRIPTION
Two resources were missing tags:
* `modules.terraform-zscc-function-app-azure.azurerm_storage_account.cc_function_storage_account`
* `modules.terraform-zscc-ccvmss-azure.azurerm_monitor_autoscale_setting.vmss_autoscale_setting`

We had a policy that was inserting tags on these resources and then getting removed from terraform.

I've verified this change fixes the issue.