### PR TITLE
Upgrade Azure RM provider to require 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use this repository to create the deployment resources required to deploy and op
 
 Our Deployment scripts are leveraging Terraform v1.1.9 which includes full binary and provider support for macOS M1 chips, but any Terraform version 0.13.7 should be generally supported.
 
-- provider registry.terraform.io/hashicorp/azurerm v3.116.x (minimum 3.108.x)
+- provider registry.terraform.io/hashicorp/azurerm >= 4.9.0, < 5.0.0
 - provider registry.terraform.io/hashicorp/random v3.3.x
 - provider registry.terraform.io/hashicorp/local v2.2.x
 - provider registry.terraform.io/hashicorp/null v3.1.x

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -40,7 +40,7 @@ From base directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -41,7 +41,7 @@ From base_1cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_1cc/versions.tf
+++ b/examples/base_1cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc_zpa/README.md
+++ b/examples/base_1cc_zpa/README.md
@@ -41,7 +41,7 @@ From base_1cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -51,7 +51,7 @@ From base_1cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base_1cc_zpa/versions.tf
+++ b/examples/base_1cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_lb/README.md
+++ b/examples/base_cc_lb/README.md
@@ -42,7 +42,7 @@ From base_cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_cc_lb/versions.tf
+++ b/examples/base_cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_lb_zpa/README.md
+++ b/examples/base_cc_lb_zpa/README.md
@@ -42,7 +42,7 @@ From base_cc_lb_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -52,7 +52,7 @@ From base_cc_lb_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base_cc_lb_zpa/versions.tf
+++ b/examples/base_cc_lb_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_vmss/README.md
+++ b/examples/base_cc_vmss/README.md
@@ -222,7 +222,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/base_cc_vmss/versions.tf
+++ b/examples/base_cc_vmss/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_vmss_zpa/README.md
+++ b/examples/base_cc_vmss_zpa/README.md
@@ -209,7 +209,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -219,7 +219,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base_cc_vmss_zpa/versions.tf
+++ b/examples/base_cc_vmss_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_lb/README.md
+++ b/examples/cc_lb/README.md
@@ -45,7 +45,7 @@ From cc_lb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/cc_lb/versions.tf
+++ b/examples/cc_lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_vmss/README.md
+++ b/examples/cc_vmss/README.md
@@ -211,7 +211,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |

--- a/examples/cc_vmss/versions.tf
+++ b/examples/cc_vmss/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/terraform-zscc-bastion-azure/README.md
+++ b/modules/terraform-zscc-bastion-azure/README.md
@@ -8,14 +8,14 @@ This module creates all Azure VM, NSG, and Public IP resources needed to deploy 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-bastion-azure/versions.tf
+++ b/modules/terraform-zscc-bastion-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-ccvm-azure/README.md
+++ b/modules/terraform-zscc-ccvm-azure/README.md
@@ -27,7 +27,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -35,7 +35,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-ccvm-azure/versions.tf
+++ b/modules/terraform-zscc-ccvm-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-ccvmss-azure/README.md
+++ b/modules/terraform-zscc-ccvmss-azure/README.md
@@ -27,7 +27,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -35,7 +35,7 @@ az vm image terms accept --urn zscaler1579058425289:zia_cloud_connector:zs_ser_g
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-ccvmss-azure/versions.tf
+++ b/modules/terraform-zscc-ccvmss-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-function-app-azure/README.md
+++ b/modules/terraform-zscc-function-app-azure/README.md
@@ -11,17 +11,17 @@ This module provides the necessary resource creation and configuration parameter
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
+| Name | Version           |
+|------|-------------------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0          |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 
 ## Modules

--- a/modules/terraform-zscc-function-app-azure/main.tf
+++ b/modules/terraform-zscc-function-app-azure/main.tf
@@ -28,7 +28,7 @@ data "azurerm_storage_account" "existing_storage_account" {
 resource "azurerm_storage_container" "cc_function_storage_container" {
   count                 = var.upload_function_app_zip ? 1 : 0
   name                  = "function-zip-container"
-  storage_account_name  = local.storage_account_name
+  storage_account_id    = local.storage_account_id
   container_access_type = "private"
 }
 
@@ -65,6 +65,7 @@ resource "azurerm_log_analytics_workspace" "vmss_orchestration_log_analytics_wor
 
 locals {
   storage_account_name       = var.existing_storage_account ? data.azurerm_storage_account.existing_storage_account[0].name : azurerm_storage_account.cc_function_storage_account[0].name
+  storage_account_id         = var.existing_storage_account ? data.azurerm_storage_account.existing_storage_account[0].id : azurerm_storage_account.cc_function_storage_account[0].id
   storage_account_access_key = var.existing_storage_account ? data.azurerm_storage_account.existing_storage_account[0].primary_access_key : azurerm_storage_account.cc_function_storage_account[0].primary_access_key
   log_analytics_workspace_id = var.existing_log_analytics_workspace ? var.existing_log_analytics_workspace_id : azurerm_log_analytics_workspace.vmss_orchestration_log_analytics_workspace[0].id
 }

--- a/modules/terraform-zscc-function-app-azure/versions.tf
+++ b/modules/terraform-zscc-function-app-azure/versions.tf
@@ -2,11 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     local = {
       source  = "hashicorp/local"
       version = "~> 2.5.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-identity-azure/README.md
+++ b/modules/terraform-zscc-identity-azure/README.md
@@ -8,13 +8,13 @@ This module takes name and resource group inputs of an existing User Managed Ide
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-identity-azure/versions.tf
+++ b/modules/terraform-zscc-identity-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-lb-azure/README.md
+++ b/modules/terraform-zscc-lb-azure/README.md
@@ -8,13 +8,13 @@ This module creates a Standard Load Balancer, backend addres pool, LB rules, and
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-lb-azure/versions.tf
+++ b/modules/terraform-zscc-lb-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-network-azure/README.md
+++ b/modules/terraform-zscc-network-azure/README.md
@@ -32,14 +32,14 @@ Subnets used for DNS resolver have the following limitations:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-network-azure/versions.tf
+++ b/modules/terraform-zscc-network-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-nsg-azure/README.md
+++ b/modules/terraform-zscc-nsg-azure/README.md
@@ -8,13 +8,13 @@ This module can be used to create default Management and Service interface NSG r
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-nsg-azure/versions.tf
+++ b/modules/terraform-zscc-nsg-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-private-dns-azure/README.md
+++ b/modules/terraform-zscc-private-dns-azure/README.md
@@ -56,13 +56,13 @@ Subnets used for DNS resolver have the following limitations:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-private-dns-azure/versions.tf
+++ b/modules/terraform-zscc-private-dns-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-workload-azure/README.md
+++ b/modules/terraform-zscc-workload-azure/README.md
@@ -8,14 +8,14 @@ This module creates all Azure VM and NSG resources needed to deploy test workloa
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.9.0, < 5.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.108.0, <= 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.9.0, < 5.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-workload-azure/versions.tf
+++ b/modules/terraform-zscc-workload-azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.108.0, <= 3.116"
+      version = ">= 4.9.0, < 5.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
We're using [AVM modules](https://azure.github.io/Azure-Verified-Modules/) in our deployment, most of those require `>= 4.9.0, < 5.0.0` which makes it a bit painful to consume these modules.

The version 3.116.0 which is the newest currently supported was Aug 16 2024, nearly 1 year ago.

I've tested this with:
* terraform-zscc-ccvmss-azure
* terraform-zscc-function-app-azure
* terraform-zscc-nsg-azure
* terraform-zscc-lb-azure

and all worked fine.