### PR TITLE
A new tag `LegacyVMNVA = "true"` to Opt-Out MANA

### DIFF
--- a/modules/terraform-zscc-ccvm-azure/main.tf
+++ b/modules/terraform-zscc-ccvm-azure/main.tf
@@ -152,7 +152,7 @@ resource "azurerm_linux_virtual_machine" "cc_vm" {
     identity_ids = [var.managed_identity_id]
   }
 
-  tags = var.global_tags
+  tags = merge(var.global_tags, { LegacyVMNVA = "true" })
 
   depends_on = [
     azurerm_network_interface_security_group_association.cc_mgmt_nic_association,

--- a/modules/terraform-zscc-ccvmss-azure/main.tf
+++ b/modules/terraform-zscc-ccvmss-azure/main.tf
@@ -88,7 +88,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "cc_vmss" {
 
   source_image_id = var.ccvm_source_image_id != null ? var.ccvm_source_image_id : null
 
-  tags = var.global_tags
+  tags = merge(var.global_tags, { LegacyVMNVA = "true" })
 
   depends_on = [
     var.backend_address_pool


### PR DESCRIPTION
A new tag `LegacyVMNVA = "true"` is being injected into both the Cloud Connector VM and the Cloud Connector VMSS resources, merged alongside any existing `global_tags`. This tag is likely used to identify legacy VM NVA (Network Virtual Appliance) deployments for filtering, policy enforcement, or migration tracking purposes.

