### PR TITLE
feat(tags): gate LegacyVMNVA tag behind enable_legacy_vm_nva_tag variable

### DIFF
--- a/modules/terraform-zscc-ccvm-azure/main.tf
+++ b/modules/terraform-zscc-ccvm-azure/main.tf
@@ -152,7 +152,7 @@ resource "azurerm_linux_virtual_machine" "cc_vm" {
     identity_ids = [var.managed_identity_id]
   }
 
-  tags = var.global_tags
+  tags = merge(var.global_tags, { LegacyVMNVA = "true" })
 
   depends_on = [
     azurerm_network_interface_security_group_association.cc_mgmt_nic_association,

--- a/modules/terraform-zscc-ccvm-azure/main.tf
+++ b/modules/terraform-zscc-ccvm-azure/main.tf
@@ -152,7 +152,7 @@ resource "azurerm_linux_virtual_machine" "cc_vm" {
     identity_ids = [var.managed_identity_id]
   }
 
-  tags = merge(var.global_tags, { LegacyVMNVA = "true" })
+  tags = merge(var.global_tags, var.enable_legacy_vm_nva_tag ? { LegacyVMNVA = "true" } : {})
 
   depends_on = [
     azurerm_network_interface_security_group_association.cc_mgmt_nic_association,

--- a/modules/terraform-zscc-ccvm-azure/variables.tf
+++ b/modules/terraform-zscc-ccvm-azure/variables.tf
@@ -16,6 +16,12 @@ variable "global_tags" {
   default     = {}
 }
 
+variable "enable_legacy_vm_nva_tag" {
+  type        = bool
+  description = "Emit the LegacyVMNVA tag on the Cloud Connector VM. Set to false once MANA host support is available."
+  default     = true
+}
+
 variable "resource_group" {
   type        = string
   description = "Main Resource Group Name"

--- a/modules/terraform-zscc-ccvmss-azure/main.tf
+++ b/modules/terraform-zscc-ccvmss-azure/main.tf
@@ -88,7 +88,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "cc_vmss" {
 
   source_image_id = var.ccvm_source_image_id != null ? var.ccvm_source_image_id : null
 
-  tags = var.global_tags
+  tags = merge(var.global_tags, { LegacyVMNVA = "true" })
 
   depends_on = [
     var.backend_address_pool

--- a/modules/terraform-zscc-ccvmss-azure/main.tf
+++ b/modules/terraform-zscc-ccvmss-azure/main.tf
@@ -88,7 +88,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "cc_vmss" {
 
   source_image_id = var.ccvm_source_image_id != null ? var.ccvm_source_image_id : null
 
-  tags = merge(var.global_tags, { LegacyVMNVA = "true" })
+  tags = merge(var.global_tags, var.enable_legacy_vm_nva_tag ? { LegacyVMNVA = "true" } : {})
 
   depends_on = [
     var.backend_address_pool

--- a/modules/terraform-zscc-ccvmss-azure/variables.tf
+++ b/modules/terraform-zscc-ccvmss-azure/variables.tf
@@ -22,6 +22,12 @@ variable "global_tags" {
   default     = {}
 }
 
+variable "enable_legacy_vm_nva_tag" {
+  type        = bool
+  description = "Emit the LegacyVMNVA tag on the Cloud Connector VMSS. Set to false once MANA host support is available."
+  default     = true
+}
+
 variable "resource_group" {
   type        = string
   description = "Main Resource Group Name"


### PR DESCRIPTION
feat(tags): gate LegacyVMNVA tag behind enable_legacy_vm_nva_tag variable
Replace the hardcoded LegacyVMNVA = "true" tag on the Cloud Connector VM
and VMSS with a bool-gated conditional merge. Adds a new variable
enable_legacy_vm_nva_tag (default true) to both modules so callers can
suppress the tag once MANA host support lands without waiting
for a module update.

Default preserves existing behavior — no plan churn for current callers.

- modules/terraform-zscc-ccvm-azure: add variable, gate tag in main.tf
- modules/terraform-zscc-ccvmss-azure: add variable, gate tag in main.tf