### PR TITLE
Azure CC: restrict ccvm_instance_type to Standard_D2ds_v5 and Standard_D2ads_v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ FEATURES:
     - add: zsec prompt create_consumer_plb to optionally create and auto-chain a consumer Public LB to the GWLB frontend (covered on first-run, .zsecrc re-use, and destroy paths across cc_gwlb, base_cc_gwlb, and base_cc_gwlb_vmss)
 
 ENHANCEMENTS:
+* add: Azure D-v5 VM/VMSS sizes `Standard_D2ds_v5` and `Standard_D2ads_v5` (adds an AMD-based option) added **additively** — legacy `Standard_D2s_v3`, `Standard_DS2_v2`, and `Standard_DS3_v2` remain in the allow-list to preserve compatibility with Azure China (Mooncake) regions where the v5 SKUs are not universally available. VM/VMSS source module and example wrapper defaults for `ccvm_instance_type` are `Standard_D2ds_v5` across all clouds; users in China regions must explicitly override `ccvm_instance_type` per-region (see each example's `terraform.tfvars` sample block). d8/d16-family and D2ds_v4 remain removed.
+* update: zsec VM size menu is now region-aware — for `chinanorth`/`chinaeast` (v1) it offers `Standard_DS2_v2`; for `chinanorth2`/`chinaeast2` it offers `Standard_D2ds_v5`, `Standard_DS3_v2`, `Standard_DS2_v2`; for `chinanorth3`/`chinaeast3` it offers `Standard_D2ds_v5`, `Standard_D2ads_v5`, `Standard_DS3_v2`, `Standard_DS2_v2`; every other Azure cloud (public) offers `Standard_D2ds_v5` and `Standard_D2ads_v5`.
 * refactor: zsec portability fixes — eliminate BSD sed artifacts so the wrapper script works consistently on macOS and Linux
 * fix: zsec no longer pre-creates .zsecrc before the deployment type is selected (prevents stale state on aborted runs)
 * refactor: rename CCVM module variables has_private_lb/has_public_lb to private_lb_enabled/public_lb_enabled to match the existing _enabled suffix convention

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -94,7 +94,7 @@ From base_1cc directory execute:
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |

--- a/examples/base_1cc/terraform.tfvars
+++ b/examples/base_1cc/terraform.tfvars
@@ -66,13 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
 #ccvm_instance_type                         = "Standard_DS3_v2"
-#ccvm_instance_type                         = "Standard_D8s_v3"
-#ccvm_instance_type                         = "Standard_D16s_v3"
-#ccvm_instance_type                         = "Standard_DS5_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. The number of Cloud Connector appliances to provision. Each incremental Cloud Connector will be created in alternating 
 ##    subnets based on the zones or byo_subnet_names variable and loop through for any deployments where cc_count > zones.

--- a/examples/base_1cc/variables.tf
+++ b/examples/base_1cc/variables.tf
@@ -92,12 +92,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_1cc_zpa/README.md
+++ b/examples/base_1cc_zpa/README.md
@@ -97,7 +97,7 @@ From base_1cc_zpa directory execute:
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector | `map(any)` | n/a | yes |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |

--- a/examples/base_1cc_zpa/terraform.tfvars
+++ b/examples/base_1cc_zpa/terraform.tfvars
@@ -66,13 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
 #ccvm_instance_type                         = "Standard_DS3_v2"
-#ccvm_instance_type                         = "Standard_D8s_v3"
-#ccvm_instance_type                         = "Standard_D16s_v3"
-#ccvm_instance_type                         = "Standard_DS5_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. The number of Cloud Connector appliances to provision. Each incremental Cloud Connector will be created in alternating 
 ##    subnets based on the zones or byo_subnet_names variable and loop through for any deployments where cc_count > zones.

--- a/examples/base_1cc_zpa/variables.tf
+++ b/examples/base_1cc_zpa/variables.tf
@@ -98,12 +98,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_cc_gwlb/README.md
+++ b/examples/base_cc_gwlb/README.md
@@ -96,7 +96,7 @@ From base_cc_lb directory execute:
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |

--- a/examples/base_cc_gwlb/terraform.tfvars
+++ b/examples/base_cc_gwlb/terraform.tfvars
@@ -66,13 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
 #ccvm_instance_type                         = "Standard_DS3_v2"
-#ccvm_instance_type                         = "Standard_D8s_v3"
-#ccvm_instance_type                         = "Standard_D16s_v3"
-#ccvm_instance_type                         = "Standard_DS5_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. The number of Cloud Connector appliances to provision. Each incremental Cloud Connector will be created in alternating 
 ##    subnets based on the zones or byo_subnet_names variable and loop through for any deployments where cc_count > zones.

--- a/examples/base_cc_gwlb/variables.tf
+++ b/examples/base_cc_gwlb/variables.tf
@@ -92,13 +92,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
       var.ccvm_instance_type == "Standard_D2ds_v5" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_cc_gwlb_vmss/README.md
+++ b/examples/base_cc_gwlb_vmss/README.md
@@ -277,7 +277,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |

--- a/examples/base_cc_gwlb_vmss/terraform.tfvars
+++ b/examples/base_cc_gwlb_vmss/terraform.tfvars
@@ -66,9 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
+#ccvm_instance_type                         = "Standard_DS3_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. By default, no zones are specified in any resource creation meaning they are either auto-assigned by Azure 
 ##    (Virtual Machines and NAT Gateways) or Zone-Redundant (Public IP) based on whatever default configuration is.

--- a/examples/base_cc_gwlb_vmss/variables.tf
+++ b/examples/base_cc_gwlb_vmss/variables.tf
@@ -92,13 +92,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
       var.ccvm_instance_type == "Standard_D2ds_v5" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_cc_lb/README.md
+++ b/examples/base_cc_lb/README.md
@@ -96,7 +96,7 @@ From base_cc_lb directory execute:
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |

--- a/examples/base_cc_lb/terraform.tfvars
+++ b/examples/base_cc_lb/terraform.tfvars
@@ -66,13 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
 #ccvm_instance_type                         = "Standard_DS3_v2"
-#ccvm_instance_type                         = "Standard_D8s_v3"
-#ccvm_instance_type                         = "Standard_D16s_v3"
-#ccvm_instance_type                         = "Standard_DS5_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. The number of Cloud Connector appliances to provision. Each incremental Cloud Connector will be created in alternating 
 ##    subnets based on the zones or byo_subnet_names variable and loop through for any deployments where cc_count > zones.

--- a/examples/base_cc_lb/variables.tf
+++ b/examples/base_cc_lb/variables.tf
@@ -92,12 +92,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_cc_lb_zpa/README.md
+++ b/examples/base_cc_lb_zpa/README.md
@@ -99,7 +99,7 @@ From base_cc_lb_zpa directory execute:
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector | `map(any)` | n/a | yes |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |

--- a/examples/base_cc_lb_zpa/terraform.tfvars
+++ b/examples/base_cc_lb_zpa/terraform.tfvars
@@ -66,13 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
 #ccvm_instance_type                         = "Standard_DS3_v2"
-#ccvm_instance_type                         = "Standard_D8s_v3"
-#ccvm_instance_type                         = "Standard_D16s_v3"
-#ccvm_instance_type                         = "Standard_DS5_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. The number of Cloud Connector appliances to provision. Each incremental Cloud Connector will be created in alternating 
 ##    subnets based on the zones or byo_subnet_names variable and loop through for any deployments where cc_count > zones.

--- a/examples/base_cc_lb_zpa/variables.tf
+++ b/examples/base_cc_lb_zpa/variables.tf
@@ -98,12 +98,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_cc_public_lb/README.md
+++ b/examples/base_cc_public_lb/README.md
@@ -150,7 +150,7 @@ From base_cc_public_lb directory execute:
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |

--- a/examples/base_cc_public_lb/terraform.tfvars
+++ b/examples/base_cc_public_lb/terraform.tfvars
@@ -66,13 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
 #ccvm_instance_type                         = "Standard_DS3_v2"
-#ccvm_instance_type                         = "Standard_D8s_v3"
-#ccvm_instance_type                         = "Standard_D16s_v3"
-#ccvm_instance_type                         = "Standard_DS5_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. The number of Cloud Connector appliances to provision. Each incremental Cloud Connector will be created in alternating 
 ##    subnets based on the zones or byo_subnet_names variable and loop through for any deployments where cc_count > zones.

--- a/examples/base_cc_public_lb/variables.tf
+++ b/examples/base_cc_public_lb/variables.tf
@@ -92,12 +92,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_cc_public_vmss/README.md
+++ b/examples/base_cc_public_vmss/README.md
@@ -276,7 +276,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |

--- a/examples/base_cc_public_vmss/terraform.tfvars
+++ b/examples/base_cc_public_vmss/terraform.tfvars
@@ -66,9 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
+#ccvm_instance_type                         = "Standard_DS3_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. By default, no zones are specified in any resource creation meaning they are either auto-assigned by Azure 
 ##    (Virtual Machines and NAT Gateways) or Zone-Redundant (Public IP) based on whatever default configuration is.

--- a/examples/base_cc_public_vmss/variables.tf
+++ b/examples/base_cc_public_vmss/variables.tf
@@ -92,12 +92,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/base_cc_vmss/README.md
+++ b/examples/base_cc_vmss/README.md
@@ -276,7 +276,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_env_subscription_id"></a> [env\_subscription\_id](#input\_env\_subscription\_id) | Azure Subscription ID where resources are to be deployed in | `string` | n/a | yes |

--- a/examples/base_cc_vmss/terraform.tfvars
+++ b/examples/base_cc_vmss/terraform.tfvars
@@ -66,9 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
+#ccvm_instance_type                         = "Standard_DS3_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. By default, no zones are specified in any resource creation meaning they are either auto-assigned by Azure 
 ##    (Virtual Machines and NAT Gateways) or Zone-Redundant (Public IP) based on whatever default configuration is.

--- a/examples/base_cc_vmss/variables.tf
+++ b/examples/base_cc_vmss/variables.tf
@@ -92,12 +92,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }
@@ -391,4 +393,3 @@ variable "public_lb_deploy" {
   description = "Deploy a Public Load-Balancer"
   default     = false
 }
-

--- a/examples/base_cc_vmss_zpa/README.md
+++ b/examples/base_cc_vmss_zpa/README.md
@@ -266,7 +266,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector | `map(any)` | n/a | yes |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |

--- a/examples/base_cc_vmss_zpa/terraform.tfvars
+++ b/examples/base_cc_vmss_zpa/terraform.tfvars
@@ -66,9 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
+#ccvm_instance_type                         = "Standard_DS3_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. By default, no zones are specified in any resource creation meaning they are either auto-assigned by Azure 
 ##    (Virtual Machines and NAT Gateways) or Zone-Redundant (Public IP) based on whatever default configuration is.

--- a/examples/base_cc_vmss_zpa/variables.tf
+++ b/examples/base_cc_vmss_zpa/variables.tf
@@ -98,12 +98,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/cc_gwlb/variables.tf
+++ b/examples/cc_gwlb/variables.tf
@@ -80,12 +80,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/cc_gwlb_vmss/variables.tf
+++ b/examples/cc_gwlb_vmss/variables.tf
@@ -80,12 +80,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/cc_lb/README.md
+++ b/examples/cc_lb/README.md
@@ -113,7 +113,7 @@ From cc_lb directory execute:
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector | `map(any)` | `{}` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `false` | no |

--- a/examples/cc_lb/terraform.tfvars
+++ b/examples/cc_lb/terraform.tfvars
@@ -66,13 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
 #ccvm_instance_type                         = "Standard_DS3_v2"
-#ccvm_instance_type                         = "Standard_D8s_v3"
-#ccvm_instance_type                         = "Standard_D16s_v3"
-#ccvm_instance_type                         = "Standard_DS5_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. The number of Cloud Connector appliances to provision. Each incremental Cloud Connector will be created in alternating 
 ##    subnets based on the zones or byo_subnet_names variable and loop through for any deployments where cc_count > zones.

--- a/examples/cc_lb/variables.tf
+++ b/examples/cc_lb/variables.tf
@@ -86,12 +86,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/cc_public_lb/terraform.tfvars
+++ b/examples/cc_public_lb/terraform.tfvars
@@ -13,6 +13,10 @@
 #network_address_space        = "10.1.0.0/16"
 #cc_count                     = 2
 #ccvm_instance_type           = "Standard_D2s_v3"
+#ccvm_instance_type           = "Standard_DS2_v2"
+#ccvm_instance_type           = "Standard_DS3_v2"
+#ccvm_instance_type           = "Standard_D2ds_v5"
+#ccvm_instance_type           = "Standard_D2ads_v5"
 #http_probe_port              = 50000
 #zones_enabled                = false
 #zones                        = ["1"]

--- a/examples/cc_public_lb/variables.tf
+++ b/examples/cc_public_lb/variables.tf
@@ -80,12 +80,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/cc_vmss/README.md
+++ b/examples/cc_vmss/README.md
@@ -279,7 +279,7 @@ To find this Mgmt IP navigate to: Resource Group -> select Scale Set -> Instance
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names fqdn/wildcard to have Azure Private DNS redirect DNS requests to Cloud Connector | `map(any)` | `{}` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |

--- a/examples/cc_vmss/terraform.tfvars
+++ b/examples/cc_vmss/terraform.tfvars
@@ -66,9 +66,13 @@
 #arm_location                               = "westus2"
 
 ## 10. Cloud Connector Azure VM Instance size selection. Uncomment ccvm_instance_type line with desired vm size to change.
-##    (Default: Standard_D2s_v3)
+##    (Default: Standard_D2ds_v5)
 
 #ccvm_instance_type                         = "Standard_D2s_v3"
+#ccvm_instance_type                         = "Standard_DS2_v2"
+#ccvm_instance_type                         = "Standard_DS3_v2"
+#ccvm_instance_type                         = "Standard_D2ds_v5"
+#ccvm_instance_type                         = "Standard_D2ads_v5"
 
 ## 11. By default, no zones are specified in any resource creation meaning they are either auto-assigned by Azure 
 ##    (Virtual Machines and NAT Gateways) or Zone-Redundant (Public IP) based on whatever default configuration is.

--- a/examples/cc_vmss/variables.tf
+++ b/examples/cc_vmss/variables.tf
@@ -86,12 +86,14 @@ variable "azure_vault_url" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_DS3_v2"
+      var.ccvm_instance_type == "Standard_DS3_v2" ||
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/examples/zsec
+++ b/examples/zsec
@@ -636,67 +636,23 @@ first_run="yes"
             PS3="${CYAN}Select desired Azure VM type for Cloud Connector: ${RESET}"
             if [[ "$azure_location" == "chinanorth" || "$azure_location" == "chinaeast" ]]; then
                 vm_sizes=("Standard_DS2_v2")
-                select ccvm_instance_type in "${vm_sizes[@]}"
-                do
-                    case $REPLY in
-                        1)
-                            echo "Cloud Connector VM type $ccvm_instance_type selected"
-                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                            break
-                            ;;
-                        *) 
-                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
-                    esac
-                done
-            elif [[ "$azure_location" == "china"* ]]; then
-                vm_sizes=("Standard_DS3_v2" "Standard_DS2_v2")
-                select ccvm_instance_type in "${vm_sizes[@]}"
-                do
-                    case $REPLY in
-                        1)
-                            echo "Cloud Connector VM type $ccvm_instance_type selected"
-                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                            break
-                            ;;
-                        2)
-                            echo "Cloud Connector VM type $ccvm_instance_type selected"
-                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                            break
-                            ;;
-                        *) 
-                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
-                    esac
-                done
+            elif [[ "$azure_location" == "chinanorth2" || "$azure_location" == "chinaeast2" ]]; then
+                vm_sizes=("Standard_DS3_v2" "Standard_D2ds_v5" "Standard_DS2_v2")
+            elif [[ "$azure_location" == "chinanorth3" || "$azure_location" == "chinaeast3" ]]; then
+                vm_sizes=("Standard_DS3_v2" "Standard_D2ds_v5" "Standard_D2ads_v5" "Standard_DS2_v2")
             else
-                vm_sizes=("Standard_D2s_v3" "Standard_DS2_v2" "Standard_DS3_v2" "Standard_D2ds_v5")
-                select ccvm_instance_type in "${vm_sizes[@]}"
-                do
-                    case $REPLY in
-                        1)
-                            echo "Cloud Connector VM type $ccvm_instance_type selected"
-                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                            break
-                            ;;
-                        2)
-                            echo "Cloud Connector VM type $ccvm_instance_type selected"
-                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                            break
-                            ;;
-                        3)
-                            echo "Cloud Connector VM type $ccvm_instance_type selected"
-                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                            break
-                            ;;
-                        4)
-                            echo "Cloud Connector VM type $ccvm_instance_type selected"
-                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                            break
-                            ;;
-                        *) 
-                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
-                    esac
-                done
+                vm_sizes=("Standard_D2ds_v5" "Standard_D2ads_v5")
             fi
+            select ccvm_instance_type in "${vm_sizes[@]}"
+            do
+                if [[ -n "$ccvm_instance_type" ]]; then
+                    echo "Cloud Connector VM type $ccvm_instance_type selected"
+                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                    break
+                else
+                    echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                fi
+            done
         fi
 
         read -r -p "${CYAN}Enter CC Provisioning URL${RESET} (E.g. connector.zscaler.net/api/v1/provUrl?name=azure_prov_url): " cc_vm_prov_url

--- a/modules/terraform-zscc-ccvm-azure/variables.tf
+++ b/modules/terraform-zscc-ccvm-azure/variables.tf
@@ -63,12 +63,9 @@ variable "ccvm_instance_type" {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS2_v2" ||
-      var.ccvm_instance_type == "Standard_D2ds_v4" ||
-      var.ccvm_instance_type == "Standard_D2ds_v5" ||
       var.ccvm_instance_type == "Standard_DS3_v2" ||
-      var.ccvm_instance_type == "Standard_D8s_v3" ||
-      var.ccvm_instance_type == "Standard_D16s_v3" ||
-      var.ccvm_instance_type == "Standard_DS5_v2"
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }

--- a/modules/terraform-zscc-ccvmss-azure/README.md
+++ b/modules/terraform-zscc-ccvmss-azure/README.md
@@ -59,7 +59,7 @@ No modules.
 | <a name="input_ccvm_image_publisher"></a> [ccvm\_image\_publisher](#input\_ccvm\_image\_publisher) | Azure Marketplace Cloud Connector Image Publisher | `string` | `"zscaler1579058425289"` | no |
 | <a name="input_ccvm_image_sku"></a> [ccvm\_image\_sku](#input\_ccvm\_image\_sku) | Azure Marketplace Cloud Connector Image SKU | `string` | `"zs_ser_gen1_cc_01"` | no |
 | <a name="input_ccvm_image_version"></a> [ccvm\_image\_version](#input\_ccvm\_image\_version) | Azure Marketplace Cloud Connector Image Version | `string` | `"latest"` | no |
-| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Image size | `string` | `"Standard_D2ds_v5"` | no |
 | <a name="input_ccvm_source_image_id"></a> [ccvm\_source\_image\_id](#input\_ccvm\_source\_image\_id) | Custom Cloud Connector Source Image ID. Set this value to the path of a local subscription Microsoft.Compute image to override the Cloud Connector deployment instead of using the marketplace publisher | `string` | `null` | no |
 | <a name="input_encryption_at_host_enabled"></a> [encryption\_at\_host\_enabled](#input\_encryption\_at\_host\_enabled) | User input for enabling or disabling host encryption | `bool` | `true` | no |
 | <a name="input_fault_domain_count"></a> [fault\_domain\_count](#input\_fault\_domain\_count) | platformFaultDomainCount must be set to 1 for max spreading or 5 for static fixed spreading. Fixed spreading with 2 or 3 fault domains isn't supported for zonal deployments | `number` | `1` | no |

--- a/modules/terraform-zscc-ccvmss-azure/variables.tf
+++ b/modules/terraform-zscc-ccvmss-azure/variables.tf
@@ -64,14 +64,13 @@ variable "ssh_key" {
 variable "ccvm_instance_type" {
   type        = string
   description = "Cloud Connector Image size"
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2ds_v5"
   validation {
     condition = (
       var.ccvm_instance_type == "Standard_D2s_v3" ||
       var.ccvm_instance_type == "Standard_DS3_v2" ||
-      var.ccvm_instance_type == "Standard_D8s_v3" ||
-      var.ccvm_instance_type == "Standard_D16s_v3" ||
-      var.ccvm_instance_type == "Standard_DS5_v2"
+      var.ccvm_instance_type == "Standard_D2ds_v5" ||
+      var.ccvm_instance_type == "Standard_D2ads_v5"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm size."
   }


### PR DESCRIPTION
As part of this pull request:

  1. Removed the retiring v1-v4 instance types from the supported list for azure public cloud. Kept some of the instances for Azure China Cloud. Removed unsupported medium and large instances everywhere.
  2. Added two new v5 instance types and set Standard_D2ds_v5 as the default for both VM and VMSS deployments.
  3. Restricted Azure Public Cloud to new v5 instances only.
  4. For china cloud, added new v5 instances selectively:
  china north, china east - new instances not supported
  china east2, china north2 - Added Standard D2ds_v5
  china east3, china north3 - Added both Standard D2ds_v5, Standard D2ads_v5
  5. Updated all examples accordingly.

Notes for reviewers:

  1. Please check the instance availability on China regions - https://confluence.corp.zscaler.com/spaces/~unnikrishnanm/pages/966165158/Azure+New+Instances+China+Region+Availability. Most of the code kept as it is for China region as there is no clarity that this retirement of instances applicable for China cloud or not. 
  2. Ran pre-commit and noticed one pre-existing bug in the GWLB deployment; this will be addressed separately by me or Ritwija.
  3. READMEs had drifted because pre-commit was not run on several prior commits, so I updated them manually.

Unit tests executed:

  1. Ran unit tests covering fmt, pre-commit, init/validate, positive and negative gate probes, two-gate source-module isolation, default-value probes, tfvars-shape, zsec menu inspection, and plan-JSON assertions on SKU and LegacyVMNVA tag across examples.
  2. Live traffic and performance testing is in progress by the team.
