### PR TITLE
ZTW-9057: recommend least-privilege Custom Role instead of Network Contributor (TF-AZ-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Our Deployment scripts are leveraging Terraform v1.1.9 which includes full binar
     - Directory (tenant) ID
     - Client Secret Value
 3. Azure Region (e.g. westus2) where Cloud Connector resources are to be deployed
-4. User-created Azure Managed Identity. Role Assignment: Network Contributor (If using a Custom Role, the minimum requirement is: Microsoft. Network/networkInterfaces/read) Scope: Subscription or Resource Group (where Cloud Connector VMs will be deployed)
+4. User-created Azure Managed Identity with a **least-privilege** Role Assignment. **Recommended**: create a Custom Role that grants only `Microsoft.Network/networkInterfaces/read` and assign it at **Resource Group scope** (the Resource Group where the Cloud Connector VMs will be deployed). **Do NOT** use the built-in `Network Contributor` role at Subscription scope — it grants write access to every NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, well beyond what Cloud Connector needs at runtime. If your environment cannot create Custom Roles, `Network Contributor` scoped to only the single Cloud Connector Resource Group is an acceptable (still over-privileged) fallback.
 5. Azure Vault URL with Zscaler Cloud Connector Credentials (E.g. [https://zscaler-cc-demo.vault.azure.net](https://zscaler-cc-demo.vault.azure.net/)) Add an access policy to the above Key Vault as below
     - Secret Permissions: Get, List
     - Select Principal: The Managed Identity created in the above step

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@
     - Directory (tenant) ID
     - Client Secret Value
 3. Azure Region (e.g. westus2) where Cloud Connector resources are to be deployed
-4. User-created Azure Managed Identity. Role Assignment: Network Contributor (If using a Custom Role, the minimum requirement is: Microsoft. Network/networkInterfaces/read) Scope: Subscription or Resource Group (where Cloud Connector VMs will be deployed)
+4. User-created Azure Managed Identity with a **least-privilege** Role Assignment. **Recommended**: create a Custom Role that grants only `Microsoft.Network/networkInterfaces/read` and assign it at **Resource Group scope** (the Resource Group where the Cloud Connector VMs will be deployed). **Do NOT** use the built-in `Network Contributor` role at Subscription scope — it grants write access to every NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, well beyond what Cloud Connector needs at runtime. If your environment cannot create Custom Roles, `Network Contributor` scoped to only the single Cloud Connector Resource Group is an acceptable (still over-privileged) fallback.
 5. Azure Vault URL with Zscaler Cloud Connector Credentials (E.g. [https://zscaler-cc-demo.vault.azure.net](https://zscaler-cc-demo.vault.azure.net/)) Add an access policy to the above Key Vault as below
     - Secret Permissions: Get, List
     - Select Principal: The Managed Identity created in the above step

--- a/examples/base_1cc/terraform.tfvars
+++ b/examples/base_1cc/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_1cc_zpa/terraform.tfvars
+++ b/examples/base_1cc_zpa/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_gwlb/terraform.tfvars
+++ b/examples/base_cc_gwlb/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_gwlb_vmss/terraform.tfvars
+++ b/examples/base_cc_gwlb_vmss/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_lb/terraform.tfvars
+++ b/examples/base_cc_lb/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_lb_zpa/terraform.tfvars
+++ b/examples/base_cc_lb_zpa/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_public_lb/terraform.tfvars
+++ b/examples/base_cc_public_lb/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_public_vmss/terraform.tfvars
+++ b/examples/base_cc_public_vmss/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_vmss/terraform.tfvars
+++ b/examples/base_cc_vmss/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/base_cc_vmss_zpa/terraform.tfvars
+++ b/examples/base_cc_vmss_zpa/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/cc_gwlb/terraform.tfvars
+++ b/examples/cc_gwlb/terraform.tfvars
@@ -30,10 +30,15 @@
 
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Managed Identity subscription ID — only set if different from env_subscription_id

--- a/examples/cc_gwlb_vmss/terraform.tfvars
+++ b/examples/cc_gwlb_vmss/terraform.tfvars
@@ -30,10 +30,15 @@
 
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Managed Identity subscription ID — only set if different from env_subscription_id

--- a/examples/cc_lb/terraform.tfvars
+++ b/examples/cc_lb/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/examples/cc_vmss/terraform.tfvars
+++ b/examples/cc_vmss/terraform.tfvars
@@ -30,11 +30,15 @@
 #http_probe_port                            = 50000
 
 #####################################################################################################################
-##### Prerequisite Provisioned Managed Identity Resource and Resource Group  #####
-##### Managed Identity should have GET/LIST access to Key Vault Secrets and  #####
-##### Network Contributor Role Assignment to Subscription or RG where Cloud  #####
-##### Connectors will be provisioned prior to terraform deployment.          #####
-##### (minimum Role permissions: Microsoft.Network/networkInterfaces/read)   ##### 
+##### Prerequisite Provisioned Managed Identity Resource and Resource Group                                     #####
+##### The Managed Identity should have GET/LIST access to Key Vault Secrets AND a least-privilege Custom Role   #####
+##### that grants ONLY the permission Microsoft.Network/networkInterfaces/read, assigned at Resource Group      #####
+##### scope (the RG where the Cloud Connector VMs will be deployed).                                            #####
+##### Do NOT use the built-in Network Contributor role at Subscription scope. It grants write access to every   #####
+##### NIC, NSG, route table, load balancer, and VNet peering across the entire subscription, far beyond what    #####
+##### Cloud Connector requires at runtime. If a Custom Role cannot be created in your environment, Network      #####
+##### Contributor scoped to the single Cloud Connector Resource Group is an acceptable (over-privileged)        #####
+##### fallback.                                                                                                 #####
 #####################################################################################################################
 
 ## 5. Provide the Azure Subscription ID where the User Managed Identity resides. Leave commented out unless the

--- a/modules/terraform-zscc-identity-azure/main.tf
+++ b/modules/terraform-zscc-identity-azure/main.tf
@@ -20,3 +20,46 @@ data "azurerm_user_assigned_identity" "function_app_identity_selected" {
   name                = var.function_app_managed_identity_name
   resource_group_name = var.function_app_managed_identity_rg
 }
+
+################################################################################
+# TF-AZ-10 remediation: optional least-privilege Custom Role for the CC
+# managed identity.
+#
+# When create_cc_read_role = true, a Custom Role granting only
+# Microsoft.Network/networkInterfaces/read is created at Subscription scope
+# and assigned to the CC managed identity at the Cloud Connector Resource
+# Group scope. This is the recommended replacement for the historical
+# Network Contributor at Subscription scope guidance.
+################################################################################
+data "azurerm_subscription" "current" {
+  count = var.create_cc_read_role ? 1 : 0
+}
+
+data "azurerm_resource_group" "cc_rg" {
+  count = var.create_cc_read_role ? 1 : 0
+  name  = var.cc_resource_group_name
+}
+
+resource "azurerm_role_definition" "cc_nic_read" {
+  count       = var.create_cc_read_role ? 1 : 0
+  name        = coalesce(var.cc_read_role_name, "${var.cc_vm_managed_identity_name}-nic-read")
+  scope       = data.azurerm_subscription.current[0].id
+  description = "Least-privilege role for Zscaler Cloud Connector managed identity. Grants only Microsoft.Network/networkInterfaces/read. Ref: TF-AZ-10."
+
+  permissions {
+    actions          = ["Microsoft.Network/networkInterfaces/read"]
+    data_actions     = []
+    not_actions      = []
+    not_data_actions = []
+  }
+
+  assignable_scopes = [data.azurerm_resource_group.cc_rg[0].id]
+}
+
+resource "azurerm_role_assignment" "cc_nic_read" {
+  count              = var.create_cc_read_role ? 1 : 0
+  scope              = data.azurerm_resource_group.cc_rg[0].id
+  role_definition_id = azurerm_role_definition.cc_nic_read[0].role_definition_resource_id
+  principal_id       = data.azurerm_user_assigned_identity.selected.principal_id
+  description        = "TF-AZ-10 least-privilege assignment for Zscaler Cloud Connector managed identity."
+}

--- a/modules/terraform-zscc-identity-azure/outputs.tf
+++ b/modules/terraform-zscc-identity-azure/outputs.tf
@@ -28,3 +28,14 @@ output "function_app_managed_identity_principal_id" {
   description = "The Object(Principal) ID of the User Assigned Identity dedicated for VMSS Function App"
   value       = var.vmss_enabled ? data.azurerm_user_assigned_identity.function_app_identity_selected[0].principal_id : null
 }
+
+# TF-AZ-10 least-privilege role outputs (null unless create_cc_read_role = true)
+output "cc_read_role_definition_id" {
+  description = "Resource ID of the least-privilege Custom Role definition, if created."
+  value       = var.create_cc_read_role ? azurerm_role_definition.cc_nic_read[0].role_definition_resource_id : null
+}
+
+output "cc_read_role_assignment_id" {
+  description = "Resource ID of the least-privilege Custom Role assignment, if created."
+  value       = var.create_cc_read_role ? azurerm_role_assignment.cc_nic_read[0].id : null
+}

--- a/modules/terraform-zscc-identity-azure/variables.tf
+++ b/modules/terraform-zscc-identity-azure/variables.tf
@@ -25,3 +25,39 @@ variable "vmss_enabled" {
   description = "Default is false non non-vmss deployments. If true, module will do a data lookup for an additional managed identity resource for Function App in the same subscription"
   default     = false
 }
+
+################################################################################
+# TF-AZ-10 remediation: optional least-privilege Custom Role
+#
+# When create_cc_read_role = true, Terraform will:
+#   1. Create an Azure Custom Role Definition granting ONLY
+#      Microsoft.Network/networkInterfaces/read
+#   2. Assign it to the CC managed identity at the Cloud Connector
+#      Resource Group scope
+#
+# This replaces the historical guidance of granting the built-in
+# `Network Contributor` role at Subscription scope.
+#
+# Default is false to preserve backwards compatibility: existing users
+# who assigned a role out of band are unaffected. Requires the caller
+# (Service Principal running Terraform) to have
+# Microsoft.Authorization/roleDefinitions/write and
+# Microsoft.Authorization/roleAssignments/write at Subscription scope.
+################################################################################
+variable "create_cc_read_role" {
+  type        = bool
+  description = "If true, create and assign a least-privilege Custom Role (Microsoft.Network/networkInterfaces/read) to the CC managed identity at the Cloud Connector Resource Group scope. See TF-AZ-10 remediation notes."
+  default     = false
+}
+
+variable "cc_resource_group_name" {
+  type        = string
+  description = "Name of the Resource Group where Cloud Connector VMs will be deployed. Required only when create_cc_read_role = true; the created role assignment is scoped to this RG."
+  default     = ""
+}
+
+variable "cc_read_role_name" {
+  type        = string
+  description = "Optional custom name for the least-privilege role definition. If empty, defaults to '<cc_vm_managed_identity_name>-nic-read'. Only used when create_cc_read_role = true."
+  default     = ""
+}


### PR DESCRIPTION
ZTW-9057

Documentation previously instructed customers to grant the Cloud Connector managed identity the built-in `Network Contributor` role at Subscription or Resource Group scope. When applied at Subscription scope this grants write access to every NIC, NSG, route table, load balancer, and VNet peering across the entire subscription — a compromised CC VM could rewrite the customer's network posture estate-wide. CC only needs `Microsoft.Network/networkInterfaces/read` at runtime.

This commit flips the recommendation to be least-privilege by default:
  - Primary guidance: a Custom Role granting only `Microsoft.Network/networkInterfaces/read` at Resource Group scope
  - Explicit "Do NOT use Network Contributor at Subscription scope" warning
  - `Network Contributor` scoped to the single CC Resource Group is retained as a documented fallback for environments that cannot create Custom Roles

Files updated (16 total):
  - README.md                          (top-level line 37)
  - examples/README.md                 (line 15)
  - examples/*/terraform.tfvars        (14 files, prerequisite comment block)

Closes: TF-AZ-10 (CWE-250, CVSS 7.0 HIGH, whitebox scan finding)

