### PR TITLE
ZTW-9056:  TF_AZ_09 separate function app identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Our Deployment scripts are leveraging Terraform v1.1.9 which includes full binar
     - Client Secret Value
 3. Azure Region (e.g. westus2) where Cloud Connector resources are to be deployed
 4. User-created Azure Managed Identity. Role Assignment: Network Contributor (If using a Custom Role, the minimum requirement is: Microsoft. Network/networkInterfaces/read) Scope: Subscription or Resource Group (where Cloud Connector VMs will be deployed)
+
+    > **VMSS deployments (`vmss_enabled = true`) — TF-AZ-09:** create a **second, separate** User-Assigned Managed Identity for the Function App autoscaler. Do **NOT** reuse the CC VM identity. The Function App requires `Microsoft.Compute/virtualMachineScaleSets/write` + `delete/action` (to add and remove CC instances) and `Key Vault Secrets User` (to read Zscaler provisioning secrets) — permissions Cloud Connector VMs themselves do not need. Sharing one identity means a compromised CC VM inherits the autoscaler's ability to delete sibling CCs and read all vault secrets. Set `function_app_managed_identity_name` and `function_app_managed_identity_rg` in your `terraform.tfvars` accordingly; Terraform plan will fail with a TF-AZ-09 error if empty or equal to the CC identity.
 5. Azure Vault URL with Zscaler Cloud Connector Credentials (E.g. [https://zscaler-cc-demo.vault.azure.net](https://zscaler-cc-demo.vault.azure.net/)) Add an access policy to the above Key Vault as below
     - Secret Permissions: Get, List
     - Select Principal: The Managed Identity created in the above step

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,8 @@
     - Client Secret Value
 3. Azure Region (e.g. westus2) where Cloud Connector resources are to be deployed
 4. User-created Azure Managed Identity. Role Assignment: Network Contributor (If using a Custom Role, the minimum requirement is: Microsoft. Network/networkInterfaces/read) Scope: Subscription or Resource Group (where Cloud Connector VMs will be deployed)
+
+    > **VMSS deployments (`vmss_enabled = true`) — TF-AZ-09:** create a **second, separate** User-Assigned Managed Identity for the Function App autoscaler. Do **NOT** reuse the CC VM identity. The Function App requires `Microsoft.Compute/virtualMachineScaleSets/write` + `delete/action` (to add and remove CC instances) and `Key Vault Secrets User` (to read Zscaler provisioning secrets) — permissions Cloud Connector VMs themselves do not need. Sharing one identity means a compromised CC VM inherits the autoscaler's ability to delete sibling CCs and read all vault secrets. Set `function_app_managed_identity_name` and `function_app_managed_identity_rg` in your `terraform.tfvars` accordingly; Terraform plan will fail with a TF-AZ-09 error if empty or equal to the CC identity.
 5. Azure Vault URL with Zscaler Cloud Connector Credentials (E.g. [https://zscaler-cc-demo.vault.azure.net](https://zscaler-cc-demo.vault.azure.net/)) Add an access policy to the above Key Vault as below
     - Secret Permissions: Get, List
     - Select Principal: The Managed Identity created in the above step

--- a/examples/base_cc_gwlb_vmss/main.tf
+++ b/examples/base_cc_gwlb_vmss/main.tf
@@ -213,7 +213,7 @@ module "cc_identity" {
   cc_vm_managed_identity_name = var.cc_vm_managed_identity_name
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
-  vmss_enabled                       = true
+  vmss_enabled = true
   # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
   # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
   function_app_managed_identity_name = var.function_app_managed_identity_name

--- a/examples/base_cc_gwlb_vmss/main.tf
+++ b/examples/base_cc_gwlb_vmss/main.tf
@@ -214,8 +214,10 @@ module "cc_identity" {
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
   vmss_enabled                       = true
-  function_app_managed_identity_name = coalesce(var.function_app_managed_identity_name, var.cc_vm_managed_identity_name)
-  function_app_managed_identity_rg   = coalesce(var.function_app_managed_identity_rg, var.cc_vm_managed_identity_rg)
+  # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
+  # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
+  function_app_managed_identity_name = var.function_app_managed_identity_name
+  function_app_managed_identity_rg   = var.function_app_managed_identity_rg
 
   #optional variable provider block defined in versions.tf to support managed identity resource being in a different subscription
   providers = {

--- a/examples/base_cc_gwlb_vmss/terraform.tfvars
+++ b/examples/base_cc_gwlb_vmss/terraform.tfvars
@@ -194,14 +194,18 @@
 #existing_storage_account_rg = "<storage-account-resource-group"
 
 
-#### Optional inputs: By default, Terraform will use the same Managed Identity as the CC VMSS for the Function App
-# Provide your existing Azure Managed Identity name to attach to the Function App. E.g tunction_app_managed_identity
+#### REQUIRED for VMSS deployments (TF-AZ-09): Function App autoscaler managed identity.
+#### This MUST reference a DIFFERENT User-Assigned Managed Identity than cc_vm_managed_identity_*
+#### above. The Function App needs VMSS Compute write/delete and Key Vault secret-read; the CC
+#### VMs do not. Sharing one identity means a compromised CC VM inherits the autoscaler's power
+#### to delete sibling CCs and read every Zscaler provisioning secret.
+#### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
-#function_app_managed_identity_name                = "function_app_managed_identity"
+# Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
+function_app_managed_identity_name                = ""
 
-# Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
-
-#function_app_managed_identity_rg                  = "function_rg_1"
+# Resource Group of the Function App Managed Identity. E.g. function_rg_1
+function_app_managed_identity_rg                  = ""
 
 # Function App uses Azure App Service Plan for hosting. Zscaler recommends leaving the default (Y1 / Flex Consumption plan), but this
 # is not available in all Azure regions. If you cannot use Y1 and you do not require VNet Integration, then choose B1. If you do need

--- a/examples/base_cc_gwlb_vmss/terraform.tfvars
+++ b/examples/base_cc_gwlb_vmss/terraform.tfvars
@@ -202,10 +202,10 @@
 #### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
 # Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
-function_app_managed_identity_name                = ""
+function_app_managed_identity_name = ""
 
 # Resource Group of the Function App Managed Identity. E.g. function_rg_1
-function_app_managed_identity_rg                  = ""
+function_app_managed_identity_rg = ""
 
 # Function App uses Azure App Service Plan for hosting. Zscaler recommends leaving the default (Y1 / Flex Consumption plan), but this
 # is not available in all Azure regions. If you cannot use Y1 and you do not require VNet Integration, then choose B1. If you do need

--- a/examples/base_cc_public_vmss/main.tf
+++ b/examples/base_cc_public_vmss/main.tf
@@ -225,8 +225,10 @@ module "cc_identity" {
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
   vmss_enabled                       = true
-  function_app_managed_identity_name = coalesce(var.function_app_managed_identity_name, var.cc_vm_managed_identity_name)
-  function_app_managed_identity_rg   = coalesce(var.function_app_managed_identity_rg, var.cc_vm_managed_identity_rg)
+  # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
+  # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
+  function_app_managed_identity_name = var.function_app_managed_identity_name
+  function_app_managed_identity_rg   = var.function_app_managed_identity_rg
 
   #optional variable provider block defined in versions.tf to support managed identity resource being in a different subscription
   providers = {

--- a/examples/base_cc_public_vmss/main.tf
+++ b/examples/base_cc_public_vmss/main.tf
@@ -224,7 +224,7 @@ module "cc_identity" {
   cc_vm_managed_identity_name = var.cc_vm_managed_identity_name
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
-  vmss_enabled                       = true
+  vmss_enabled = true
   # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
   # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
   function_app_managed_identity_name = var.function_app_managed_identity_name

--- a/examples/base_cc_public_vmss/terraform.tfvars
+++ b/examples/base_cc_public_vmss/terraform.tfvars
@@ -202,7 +202,7 @@
 #### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
 # Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
-function_app_managed_identity_name                = ""
+function_app_managed_identity_name = ""
 
 # Resource Group of the Function App Managed Identity. E.g. function_rg_1
-function_app_managed_identity_rg                  = ""
+function_app_managed_identity_rg = ""

--- a/examples/base_cc_public_vmss/terraform.tfvars
+++ b/examples/base_cc_public_vmss/terraform.tfvars
@@ -194,11 +194,15 @@
 #existing_storage_account_rg = "<storage-account-resource-group"
 
 
-#### Optional inputs: By default, Terraform will use the same Managed Identity as the CC VMSS for the Function App
-# Provide your existing Azure Managed Identity name to attach to the Function App. E.g tunction_app_managed_identity
+#### REQUIRED for VMSS deployments (TF-AZ-09): Function App autoscaler managed identity.
+#### This MUST reference a DIFFERENT User-Assigned Managed Identity than cc_vm_managed_identity_*
+#### above. The Function App needs VMSS Compute write/delete and Key Vault secret-read; the CC
+#### VMs do not. Sharing one identity means a compromised CC VM inherits the autoscaler's power
+#### to delete sibling CCs and read every Zscaler provisioning secret.
+#### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
-#function_app_managed_identity_name                = "function_app_managed_identity"
+# Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
+function_app_managed_identity_name                = ""
 
-# Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
-
-#function_app_managed_identity_rg                  = "function_rg_1"
+# Resource Group of the Function App Managed Identity. E.g. function_rg_1
+function_app_managed_identity_rg                  = ""

--- a/examples/base_cc_vmss/main.tf
+++ b/examples/base_cc_vmss/main.tf
@@ -228,8 +228,10 @@ module "cc_identity" {
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
   vmss_enabled                       = true
-  function_app_managed_identity_name = coalesce(var.function_app_managed_identity_name, var.cc_vm_managed_identity_name)
-  function_app_managed_identity_rg   = coalesce(var.function_app_managed_identity_rg, var.cc_vm_managed_identity_rg)
+  # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
+  # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
+  function_app_managed_identity_name = var.function_app_managed_identity_name
+  function_app_managed_identity_rg   = var.function_app_managed_identity_rg
 
   #optional variable provider block defined in versions.tf to support managed identity resource being in a different subscription
   providers = {

--- a/examples/base_cc_vmss/main.tf
+++ b/examples/base_cc_vmss/main.tf
@@ -227,7 +227,7 @@ module "cc_identity" {
   cc_vm_managed_identity_name = var.cc_vm_managed_identity_name
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
-  vmss_enabled                       = true
+  vmss_enabled = true
   # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
   # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
   function_app_managed_identity_name = var.function_app_managed_identity_name

--- a/examples/base_cc_vmss/terraform.tfvars
+++ b/examples/base_cc_vmss/terraform.tfvars
@@ -202,7 +202,7 @@
 #### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
 # Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
-function_app_managed_identity_name                = ""
+function_app_managed_identity_name = ""
 
 # Resource Group of the Function App Managed Identity. E.g. function_rg_1
-function_app_managed_identity_rg                  = ""
+function_app_managed_identity_rg = ""

--- a/examples/base_cc_vmss/terraform.tfvars
+++ b/examples/base_cc_vmss/terraform.tfvars
@@ -194,11 +194,15 @@
 #existing_storage_account_rg = "<storage-account-resource-group"
 
 
-#### Optional inputs: By default, Terraform will use the same Managed Identity as the CC VMSS for the Function App
-# Provide your existing Azure Managed Identity name to attach to the Function App. E.g tunction_app_managed_identity
+#### REQUIRED for VMSS deployments (TF-AZ-09): Function App autoscaler managed identity.
+#### This MUST reference a DIFFERENT User-Assigned Managed Identity than cc_vm_managed_identity_*
+#### above. The Function App needs VMSS Compute write/delete and Key Vault secret-read; the CC
+#### VMs do not. Sharing one identity means a compromised CC VM inherits the autoscaler's power
+#### to delete sibling CCs and read every Zscaler provisioning secret.
+#### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
-#function_app_managed_identity_name                = "function_app_managed_identity"
+# Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
+function_app_managed_identity_name                = ""
 
-# Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
-
-#function_app_managed_identity_rg                  = "function_rg_1"
+# Resource Group of the Function App Managed Identity. E.g. function_rg_1
+function_app_managed_identity_rg                  = ""

--- a/examples/base_cc_vmss_zpa/main.tf
+++ b/examples/base_cc_vmss_zpa/main.tf
@@ -229,7 +229,7 @@ module "cc_identity" {
   cc_vm_managed_identity_name = var.cc_vm_managed_identity_name
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
-  vmss_enabled                       = true
+  vmss_enabled = true
   # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
   # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
   function_app_managed_identity_name = var.function_app_managed_identity_name

--- a/examples/base_cc_vmss_zpa/main.tf
+++ b/examples/base_cc_vmss_zpa/main.tf
@@ -230,8 +230,10 @@ module "cc_identity" {
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
   vmss_enabled                       = true
-  function_app_managed_identity_name = coalesce(var.function_app_managed_identity_name, var.cc_vm_managed_identity_name)
-  function_app_managed_identity_rg   = coalesce(var.function_app_managed_identity_rg, var.cc_vm_managed_identity_rg)
+  # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
+  # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
+  function_app_managed_identity_name = var.function_app_managed_identity_name
+  function_app_managed_identity_rg   = var.function_app_managed_identity_rg
 
   #optional variable provider block defined in versions.tf to support managed identity resource being in a different subscription
   providers = {

--- a/examples/base_cc_vmss_zpa/terraform.tfvars
+++ b/examples/base_cc_vmss_zpa/terraform.tfvars
@@ -225,7 +225,7 @@
 #### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
 # Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
-function_app_managed_identity_name                = ""
+function_app_managed_identity_name = ""
 
 # Resource Group of the Function App Managed Identity. E.g. function_rg_1
-function_app_managed_identity_rg                  = ""
+function_app_managed_identity_rg = ""

--- a/examples/base_cc_vmss_zpa/terraform.tfvars
+++ b/examples/base_cc_vmss_zpa/terraform.tfvars
@@ -217,11 +217,15 @@
 #existing_storage_account_rg = "<storage-account-resource-group"
 
 
-#### Optional inputs: By default, Terraform will use the same Managed Identity as the CC VMSS for the Function App
-# Provide your existing Azure Managed Identity name to attach to the Function App. E.g tunction_app_managed_identity
+#### REQUIRED for VMSS deployments (TF-AZ-09): Function App autoscaler managed identity.
+#### This MUST reference a DIFFERENT User-Assigned Managed Identity than cc_vm_managed_identity_*
+#### above. The Function App needs VMSS Compute write/delete and Key Vault secret-read; the CC
+#### VMs do not. Sharing one identity means a compromised CC VM inherits the autoscaler's power
+#### to delete sibling CCs and read every Zscaler provisioning secret.
+#### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
-#function_app_managed_identity_name                = "function_app_managed_identity"
+# Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
+function_app_managed_identity_name                = ""
 
-# Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
-
-#function_app_managed_identity_rg                  = "function_rg_1"
+# Resource Group of the Function App Managed Identity. E.g. function_rg_1
+function_app_managed_identity_rg                  = ""

--- a/examples/cc_gwlb_vmss/main.tf
+++ b/examples/cc_gwlb_vmss/main.tf
@@ -212,7 +212,7 @@ module "cc_identity" {
   cc_vm_managed_identity_name = var.cc_vm_managed_identity_name
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
-  vmss_enabled                       = true
+  vmss_enabled = true
   # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
   # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
   function_app_managed_identity_name = var.function_app_managed_identity_name

--- a/examples/cc_gwlb_vmss/main.tf
+++ b/examples/cc_gwlb_vmss/main.tf
@@ -213,8 +213,10 @@ module "cc_identity" {
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
   vmss_enabled                       = true
-  function_app_managed_identity_name = coalesce(var.function_app_managed_identity_name, var.cc_vm_managed_identity_name)
-  function_app_managed_identity_rg   = coalesce(var.function_app_managed_identity_rg, var.cc_vm_managed_identity_rg)
+  # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
+  # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
+  function_app_managed_identity_name = var.function_app_managed_identity_name
+  function_app_managed_identity_rg   = var.function_app_managed_identity_rg
 
   #optional variable provider block defined in versions.tf to support managed identity resource being in a different subscription
   providers = {

--- a/examples/cc_gwlb_vmss/terraform.tfvars
+++ b/examples/cc_gwlb_vmss/terraform.tfvars
@@ -45,6 +45,16 @@
 #cc_vm_managed_identity_name = "cloud_connector_managed_identity"
 #cc_vm_managed_identity_rg   = "cloud_connector_rg_1"
 
+## 6b. REQUIRED for VMSS deployments (TF-AZ-09): Function App autoscaler managed identity.
+## This MUST reference a DIFFERENT User-Assigned Managed Identity than cc_vm_managed_identity_*
+## above. The Function App needs VMSS Compute write/delete and Key Vault secret-read; the CC
+## VMs do not. Sharing one identity means a compromised CC VM inherits the autoscaler's power
+## to delete sibling CCs and read every Zscaler provisioning secret.
+## Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
+
+function_app_managed_identity_name = ""
+function_app_managed_identity_rg   = ""
+
 
 #####################################################################################################################
 ##### BYO (Bring Your Own) — existing infrastructure                                      #####

--- a/examples/cc_vmss/main.tf
+++ b/examples/cc_vmss/main.tf
@@ -213,7 +213,7 @@ module "cc_identity" {
   cc_vm_managed_identity_name = var.cc_vm_managed_identity_name
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
-  vmss_enabled                       = true
+  vmss_enabled = true
   # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
   # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
   function_app_managed_identity_name = var.function_app_managed_identity_name

--- a/examples/cc_vmss/main.tf
+++ b/examples/cc_vmss/main.tf
@@ -214,8 +214,10 @@ module "cc_identity" {
   cc_vm_managed_identity_rg   = var.cc_vm_managed_identity_rg
 
   vmss_enabled                       = true
-  function_app_managed_identity_name = coalesce(var.function_app_managed_identity_name, var.cc_vm_managed_identity_name)
-  function_app_managed_identity_rg   = coalesce(var.function_app_managed_identity_rg, var.cc_vm_managed_identity_rg)
+  # TF-AZ-09: Function App autoscaler MUST use a managed identity DISTINCT from cc_vm_managed_identity_*.
+  # Empty or equal-to-CC values will fail plan (see terraform-zscc-identity-azure preconditions).
+  function_app_managed_identity_name = var.function_app_managed_identity_name
+  function_app_managed_identity_rg   = var.function_app_managed_identity_rg
 
   #optional variable provider block defined in versions.tf to support managed identity resource being in a different subscription
   providers = {

--- a/examples/cc_vmss/terraform.tfvars
+++ b/examples/cc_vmss/terraform.tfvars
@@ -320,11 +320,15 @@
 #existing_storage_account_rg = "<storage-account-resource-group"
 
 
-#### Optional inputs: By default, Terraform will use the same Managed Identity as the CC VMSS for the Function App
-# Provide your existing Azure Managed Identity name to attach to the Function App. E.g tunction_app_managed_identity
+#### REQUIRED for VMSS deployments (TF-AZ-09): Function App autoscaler managed identity.
+#### This MUST reference a DIFFERENT User-Assigned Managed Identity than cc_vm_managed_identity_*
+#### above. The Function App needs VMSS Compute write/delete and Key Vault secret-read; the CC
+#### VMs do not. Sharing one identity means a compromised CC VM inherits the autoscaler's power
+#### to delete sibling CCs and read every Zscaler provisioning secret.
+#### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
-#function_app_managed_identity_name                = "function_app_managed_identity"
+# Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
+function_app_managed_identity_name                = ""
 
-# Provide the existing Resource Group of the Azure Managed Identity name to attach to the CC VM. E.g. function_connector_rg_1
-
-#function_app_managed_identity_rg                  = "function_rg_1"
+# Resource Group of the Function App Managed Identity. E.g. function_rg_1
+function_app_managed_identity_rg                  = ""

--- a/examples/cc_vmss/terraform.tfvars
+++ b/examples/cc_vmss/terraform.tfvars
@@ -328,7 +328,7 @@
 #### Terraform plan will FAIL with a TF-AZ-09 error if these are empty or match the CC identity.
 
 # Name of the User-Assigned Managed Identity to attach to the Function App. E.g. function_app_managed_identity
-function_app_managed_identity_name                = ""
+function_app_managed_identity_name = ""
 
 # Resource Group of the Function App Managed Identity. E.g. function_rg_1
-function_app_managed_identity_rg                  = ""
+function_app_managed_identity_rg = ""

--- a/modules/terraform-zscc-identity-azure/main.tf
+++ b/modules/terraform-zscc-identity-azure/main.tf
@@ -39,3 +39,79 @@ data "azurerm_user_assigned_identity" "function_app_identity_selected" {
     }
   }
 }
+
+################################################################################
+# TF-AZ-09 remediation (opt-in): least-privilege Custom Role + assignments
+# for the Function App autoscaler managed identity.
+#
+# Guarded by create_function_app_role. When true, provisions:
+#   * A Custom Role Definition (VMSS Compute read/write + per-instance
+#     read/write/delete) scoped to the CC Resource Group.
+#   * A role assignment binding that custom role to the Function App
+#     managed identity at the CC Resource Group scope.
+#   * A role assignment binding the built-in "Key Vault Secrets User"
+#     role to the Function App managed identity at the CC Resource
+#     Group scope (autoscaler needs to read Zscaler provisioning secrets).
+################################################################################
+data "azurerm_subscription" "fa_current" {
+  count = var.create_function_app_role ? 1 : 0
+}
+
+data "azurerm_resource_group" "fa_cc_rg" {
+  count = var.create_function_app_role ? 1 : 0
+  name  = var.cc_resource_group_name
+
+  lifecycle {
+    precondition {
+      condition     = var.vmss_enabled
+      error_message = "TF-AZ-09: create_function_app_role requires vmss_enabled = true. The Function App identity only exists in VMSS deployments."
+    }
+    precondition {
+      condition     = var.cc_resource_group_name != ""
+      error_message = "TF-AZ-09: create_function_app_role requires cc_resource_group_name to be set. This is the Resource Group scope for both the custom role's assignable_scopes and both role assignments."
+    }
+  }
+}
+
+resource "azurerm_role_definition" "function_app_vmss_ops" {
+  count       = var.create_function_app_role ? 1 : 0
+  name        = coalesce(var.function_app_role_name, "${var.function_app_managed_identity_name}-vmss-ops")
+  scope       = data.azurerm_subscription.fa_current[0].id
+  description = "Least-privilege role for Zscaler CC Function App autoscaler. Grants only VMSS Compute read/write + per-instance read/write/delete on the CC Resource Group. Ref: TF-AZ-09."
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/virtualMachineScaleSets/read",
+      "Microsoft.Compute/virtualMachineScaleSets/write",
+      "Microsoft.Compute/virtualMachineScaleSets/delete/action",
+      "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+      "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write",
+      "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/delete",
+    ]
+    data_actions     = []
+    not_actions      = []
+    not_data_actions = []
+  }
+
+  assignable_scopes = [data.azurerm_resource_group.fa_cc_rg[0].id]
+}
+
+resource "azurerm_role_assignment" "function_app_vmss_ops" {
+  count              = var.create_function_app_role ? 1 : 0
+  scope              = data.azurerm_resource_group.fa_cc_rg[0].id
+  role_definition_id = azurerm_role_definition.function_app_vmss_ops[0].role_definition_resource_id
+  principal_id       = data.azurerm_user_assigned_identity.function_app_identity_selected[0].principal_id
+  description        = "TF-AZ-09 least-privilege VMSS ops assignment for Zscaler CC Function App autoscaler."
+}
+
+# Built-in role: 'Key Vault Secrets User' — read secret contents (get/list secret versions).
+# Assigned at CC RG scope so the autoscaler can read Zscaler provisioning secrets from
+# any Key Vault in the CC RG. If tighter scoping to a specific vault is required,
+# customers can create the assignment out of band and leave create_function_app_role = false.
+resource "azurerm_role_assignment" "function_app_kv_secrets" {
+  count                = var.create_function_app_role ? 1 : 0
+  scope                = data.azurerm_resource_group.fa_cc_rg[0].id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = data.azurerm_user_assigned_identity.function_app_identity_selected[0].principal_id
+  description          = "TF-AZ-09 Key Vault secret-read assignment for Zscaler CC Function App autoscaler."
+}

--- a/modules/terraform-zscc-identity-azure/main.tf
+++ b/modules/terraform-zscc-identity-azure/main.tf
@@ -10,13 +10,32 @@ data "azurerm_user_assigned_identity" "selected" {
 
 
 ################################################################################
-# Reference inputs to obtain an existing User Managed Identity Resource 
-# to associate to to Function App. 
-
-# *Optional* - By default, CCs and Function will use the same Identity
+# Reference inputs to obtain an existing User Managed Identity Resource
+# to associate to the Function App autoscaler.
+#
+# TF-AZ-09 remediation: this identity MUST be a distinct User-Assigned
+# Managed Identity from the one attached to the Cloud Connector VMs. The
+# Function App requires VMSS Compute write/delete and Key Vault secret-read
+# permissions that Cloud Connector VMs do not need; reusing a single
+# identity across both components means a compromised CC VM inherits the
+# Function App's power to delete sibling CCs and read all vault secrets.
+#
+# The precondition below fails plan when vmss_enabled = true and no
+# separate Function App identity has been supplied.
 ################################################################################
 data "azurerm_user_assigned_identity" "function_app_identity_selected" {
   count               = var.vmss_enabled ? 1 : 0
   name                = var.function_app_managed_identity_name
   resource_group_name = var.function_app_managed_identity_rg
+
+  lifecycle {
+    precondition {
+      condition     = var.function_app_managed_identity_name != "" && var.function_app_managed_identity_rg != ""
+      error_message = "TF-AZ-09: A separate managed identity is required for the Function App when vmss_enabled = true. Set function_app_managed_identity_name and function_app_managed_identity_rg to a DISTINCT identity from cc_vm_managed_identity_name/rg. Reusing the CC VM identity grants a compromised CC instance the ability to delete sibling CCs and read all Function App secrets. See README.md prerequisites and TF-AZ-09 remediation notes."
+    }
+    precondition {
+      condition     = var.function_app_managed_identity_name != var.cc_vm_managed_identity_name || var.function_app_managed_identity_rg != var.cc_vm_managed_identity_rg
+      error_message = "TF-AZ-09: function_app_managed_identity_name/rg must reference a DIFFERENT managed identity than cc_vm_managed_identity_name/rg. Both currently point to the same identity, which recreates the shared-identity privilege-escalation exposure this control is designed to prevent."
+    }
+  }
 }

--- a/modules/terraform-zscc-identity-azure/outputs.tf
+++ b/modules/terraform-zscc-identity-azure/outputs.tf
@@ -28,3 +28,19 @@ output "function_app_managed_identity_principal_id" {
   description = "The Object(Principal) ID of the User Assigned Identity dedicated for VMSS Function App"
   value       = var.vmss_enabled ? data.azurerm_user_assigned_identity.function_app_identity_selected[0].principal_id : null
 }
+
+# TF-AZ-09 least-privilege role outputs (null unless create_function_app_role = true)
+output "function_app_role_definition_id" {
+  description = "Resource ID of the least-privilege Function App VMSS ops Custom Role definition, if created."
+  value       = var.create_function_app_role ? azurerm_role_definition.function_app_vmss_ops[0].role_definition_resource_id : null
+}
+
+output "function_app_role_assignment_id" {
+  description = "Resource ID of the least-privilege Function App VMSS ops Custom Role assignment, if created."
+  value       = var.create_function_app_role ? azurerm_role_assignment.function_app_vmss_ops[0].id : null
+}
+
+output "function_app_kv_secrets_role_assignment_id" {
+  description = "Resource ID of the 'Key Vault Secrets User' role assignment for the Function App identity, if created."
+  value       = var.create_function_app_role ? azurerm_role_assignment.function_app_kv_secrets[0].id : null
+}

--- a/modules/terraform-zscc-identity-azure/variables.tf
+++ b/modules/terraform-zscc-identity-azure/variables.tf
@@ -25,3 +25,43 @@ variable "vmss_enabled" {
   description = "Default is false non non-vmss deployments. If true, module will do a data lookup for an additional managed identity resource for Function App in the same subscription"
   default     = false
 }
+
+################################################################################
+# TF-AZ-09 remediation: optional least-privilege Custom Role for the CC
+# Function App autoscaler managed identity.
+#
+# When create_function_app_role = true, Terraform will:
+#   1. Create a Custom Role granting only the VMSS Compute operations the
+#      Function App autoscaler actually needs (read/write VMSS +
+#      per-instance read/write/delete).
+#   2. Assign that custom role at the CC Resource Group scope.
+#   3. Additionally assign the built-in 'Key Vault Secrets User' role at
+#      the CC Resource Group scope so the autoscaler can read Zscaler
+#      provisioning secrets.
+#
+# Default false preserves backwards compatibility: existing users who
+# assigned roles out of band are unaffected. Requires vmss_enabled = true
+# and both function_app_managed_identity_name/_rg to be non-empty
+# (enforced by the module preconditions).
+#
+# Requires the caller (Service Principal running Terraform) to have
+# Microsoft.Authorization/roleDefinitions/write and
+# Microsoft.Authorization/roleAssignments/write at Subscription scope.
+################################################################################
+variable "create_function_app_role" {
+  type        = bool
+  description = "If true, create a least-privilege Custom Role for the Function App autoscaler (VMSS Compute ops) and assign it — plus 'Key Vault Secrets User' — to the Function App managed identity at the CC Resource Group scope. Requires vmss_enabled = true. See TF-AZ-09 remediation notes."
+  default     = false
+}
+
+variable "cc_resource_group_name" {
+  type        = string
+  description = "Name of the Resource Group where Cloud Connector VMs and their Key Vault will be deployed. Required when create_function_app_role = true (used as the assignable_scope + role_assignment scope) and/or when create_cc_read_role = true."
+  default     = ""
+}
+
+variable "function_app_role_name" {
+  type        = string
+  description = "Optional custom name for the Function App VMSS ops role definition. If empty, defaults to '<function_app_managed_identity_name>-vmss-ops'. Only used when create_function_app_role = true."
+  default     = ""
+}


### PR DESCRIPTION
Fixes TF-AZ-09 (CWE-269 · CVSS 7.0 HIGH · whitebox scan finding): the CC VM and Function App autoscaler share a single Azure User-Assigned Managed Identity by default in all VMSS example deployments. This lets a compromised CC VM inherit the autoscaler's ability to delete sibling CC instances and read every Zscaler provisioning secret from Key Vault.