### PR TITLE
ZTW-10952: set Standard SKU on public IP 

### DIFF
--- a/modules/terraform-zscc-bastion-azure/main.tf
+++ b/modules/terraform-zscc-bastion-azure/main.tf
@@ -30,6 +30,7 @@ resource "azurerm_public_ip" "bastion_pip" {
   location                = var.location
   resource_group_name     = var.resource_group
   allocation_method       = "Static"
+  sku                     = "Standard"
   idle_timeout_in_minutes = 30
 
   tags = var.global_tags


### PR DESCRIPTION
One-line fix in main.tf:33  added sku = "Standard" to azurerm_public_ip.bastion_pip, matching the pattern already used in terraform-zscc-network-azure and terraform-zscc-public-lb-azure. Fixes the IPv4BasicSkuPublicIpCountLimitReached error from Azure's Basic SKU retirement (9/30/2025).

Verified with terraform fmt -check and terraform validate against examples/base before committing.